### PR TITLE
Devcontainer support

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"name": "ludeeus/integration_blueprint",
+	"image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye",
+	"postCreateCommand": "scripts/setup",
+	"forwardPorts": [
+		8123
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"github.vscode-pull-request-github",
+				"ryanluker.vscode-coverage-gutters",
+				"ms-python.vscode-pylance"
+			],
+			"settings": {
+				"files.eol": "\n",
+				"editor.tabSize": 4,
+				"python.pythonPath": "/usr/bin/python3",
+				"python.analysis.autoSearchPaths": false,
+				"python.linting.pylintEnabled": true,
+				"python.linting.enabled": true,
+				"python.formatting.provider": "black",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"editor.formatOnPaste": false,
+				"editor.formatOnSave": true,
+				"editor.formatOnType": true,
+				"files.trimTrailingWhitespace": true
+			}
+		}
+	},
+	"remoteUser": "vscode"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,19 @@
 **/__pycache__
 **.DS_Store
 **@eaDir
+
+# Home Assistant configuration
+.cloud
+.HA_VERSION
+.storage
+automations.yaml
+blueprints
+configuration.yaml
+!/configuration.yaml
+deps
+home-assistant_v2*
+home-assistant.log*
+tts
+scenes.yaml
+scripts.yaml
+secrets.yaml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Example of attaching to local debug server
+      "name": "Python: Attach Local",
+      "type": "python",
+      "request": "attach",
+      "port": 5678,
+      "host": "localhost",
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "."
+        }
+      ]
+    },
+    {
+      // Example of attaching to my production server
+      "name": "Python: Attach Remote",
+      "type": "python",
+      "request": "attach",
+      "port": 5678,
+      "host": "homeassistant.local",
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/usr/src/homeassistant"
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    },
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 8123",
+            "type": "shell",
+            "command": "scripts/develop",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,0 +1,8 @@
+# https://www.home-assistant.io/integrations/default_config/
+default_config:
+
+# https://www.home-assistant.io/integrations/logger/
+logger:
+  default: info
+  logs:
+    custom_components.ha_hatch: debug

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -6,3 +6,4 @@ logger:
   default: info
   logs:
     custom_components.ha_hatch: debug
+    hatch_rest_api: debug

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+colorlog>=6.7.0
+homeassistant>=2023.3.1
+ruff>=0.0.254
+hatch-rest-api==1.20.0

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Start Home Assistant
+hass -c . --debug

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+ruff check . --fix

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
I am working on adding support for the Restore and Restore 2 if possible, and as part of that I set up my local version of the repository to allow me to easily develop and debug it using vscode and devcontainers.

Rather than deleting those files when I'm done, I thought it might be better to submit them as a PR so that you can consider whether or not you'd like to include it in the main repo.

These changes are developer-facing quality-of-life improvements and wouldn't affect the actual custom component in any way.

Using these changes, simply starting the devcontainer (which vscode should offer to do automatically) will install homeassistant in a Docker container and give it access to the custom component. Then, running the "Run Home Assistant on port 8123" task in vscode starts HA and opens a port from the devcontainer so that you can visit http://localhost:8123 to test the custom component.

Feel free to change how I've set this up, or just reject it entirely if you're not interested in supporting devcontainer-based development.

Thanks for considering these changes!