### PR TITLE
Fix package installation for debian and ubuntu containers

### DIFF
--- a/custom_components/ha_hatch/__init__.py
+++ b/custom_components/ha_hatch/__init__.py
@@ -82,7 +82,7 @@ def _install_package_dependencies():
             )
         else:
             _LOGGER.warning(
-                """ Unsupported distro: %s. If you run into issues, make sure you have
+                """Unsupported distro: %s. If you run into issues, make sure you have
                 gcc, g++, cmake, and make installed in your Home Assistant container.""",
                 distro_id,
             )

--- a/custom_components/ha_hatch/__init__.py
+++ b/custom_components/ha_hatch/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+import distro
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -52,26 +53,43 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def _install_alpine_dependencies():
-    if is_docker_env() and not is_virtual_env():
-        args = ["apk", "add", "gcc", "g++", "cmake", "make"]
-        with Popen(
-            args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=os.environ.copy()
-        ) as process:
-            _, stderr = process.communicate()
-            if process.returncode != 0:
-                _LOGGER.error("Unable to install alpine dependency")
-                try:
-                    _LOGGER.error(stderr.decode("utf-8").lstrip().strip())
-                except Exception as error:
-                    _LOGGER.error(error)
-                return False
+def _install_distro_packages(args, errMsg="Unable to install package dependencies"):
+    if os.geteuid() != 0:
+        args.insert(0, "sudo")
+    with Popen(
+        args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=os.environ.copy()
+    ) as process:
+        _, stderr = process.communicate()
+        if process.returncode != 0:
+            _LOGGER.error(errMsg)
+            try:
+                _LOGGER.error(stderr.decode("utf-8").lstrip().strip())
+            except Exception as error:
+                _LOGGER.error(error)
 
-    return True
+
+def _install_package_dependencies():
+    if is_docker_env() and not is_virtual_env():
+        distro_id = distro.id()
+        if distro_id == "alpine":
+            _install_distro_packages(["apk", "add", "gcc", "g++", "cmake", "make"])
+        elif distro_id == "debian" or distro_id == "ubuntu":
+            _install_distro_packages(
+                ["apt-get", "update"], "Failed to update available packages"
+            )
+            _install_distro_packages(
+                ["apt-get", "install", "build-essential", "cmake", "-y"]
+            )
+        else:
+            _LOGGER.warning(
+                """ Unsupported distro: %s. If you run into issues, make sure you have
+                gcc, g++, cmake, and make installed in your Home Assistant container.""",
+                distro_id,
+            )
 
 
 def _lazy_install():
-    _install_alpine_dependencies()
+    _install_package_dependencies()
     custom_required_packages = [f"hatch-rest-api=={API_VERSION}"]
     links = "https://qqaatw.github.io/aws-crt-python-musllinux/"
     for pkg in custom_required_packages:

--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/dahlb/ha_hatch",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
-  "requirements": [],
+  "requirements": ["distro>=1.0.0"],
   "version": "1.14.1"
 }


### PR DESCRIPTION
This is one solution to resolving the issue discussed in https://github.com/dahlb/ha_hatch/issues/39. When running Home Assistant inside of a Docker container other than Alpine Linux, the setup process would error out due to trying to invoke the apk command and receiving the error that it is unknown.

This PR uses the distro package to maintain the existing functionality for Alpine containers, and adds similar functionality for Ubuntu and Debian. It also outputs a warning for any other Docker-based distro indicating that manual installation of those package might be necessary.

Since many Docker containers also don't run as root, I also added a bit of code that prefixes the command with "sudo" for anyone other than uid 0. An alternative would be to skip package installation if not root. I'm not sure which would be preferable, but that's easy to change.

## An alternative solution
All that being said, it feels like installing OS packages should perhaps be out of scope for a custom integration. There's no way to know if the Docker container is a dev box or if it's someone's production HA instance. And the fact that it only runs when it's in a Docker container means that many HA installations won't run that code anyway, so is it really necessary at all?

I wonder if the better solution would be to just remove the OS package installation code, and if those packages are really needed, output a log error if they're missing telling the user to install them. This would be safer, and wouldn't require checking for various distros or making unannounced changes to the host machine. If this would be an acceptable change, I could submit a PR for that instead of this one.