### PR TITLE
handle None in riot_clock_entity

### DIFF
--- a/custom_components/ha_hatch/riot_clock_entity.py
+++ b/custom_components/ha_hatch/riot_clock_entity.py
@@ -27,7 +27,8 @@ class RiotClockEntity(RestEntity, LightEntity):
         _LOGGER.debug(f"updating state:{self.rest_device}")
         if isinstance(self.rest_device, RestIot):
             self._attr_is_on = self.rest_device.is_clock_on
-        self._attr_brightness = round(self.rest_device.clock / 100 * 255.0, 0)
+        clock_val = self.rest_device.clock or 0.0
+        self._attr_brightness = round(clock_val / 100 * 255.0, 0)
         self.async_write_ha_state()
 
     def turn_on(self, **kwargs):


### PR DESCRIPTION
Avoid this error seen on Home Assistant startup:
```
  File "/config/custom_components/ha_hatch/riot_clock_entity.py", line 30, in _update_local_state
    self._attr_brightness = round(self.rest_device.clock / 100 * 255.0, 0)
                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```