### PR TITLE
feat: show rest device favorites in sound mode list for RIoT media entity

### DIFF
--- a/custom_components/ha_hatch/riot_media_entity.py
+++ b/custom_components/ha_hatch/riot_media_entity.py
@@ -25,7 +25,7 @@ class RiotMediaEntity(RestEntity, MediaPlayerEntity):
 
     def __init__(self, rest_device: RestIot | RestoreIot):
         super().__init__(rest_device, "Media Player")
-        self._attr_sound_mode_list = [x.name for x in REST_IOT_AUDIO_TRACKS[1:]]
+        self._attr_sound_mode_list = self.rest_device.favorite_names() + [x.name for x in REST_IOT_AUDIO_TRACKS[1:]]
         self._attr_supported_features = (
             MediaPlayerEntityFeature.PLAY
             | MediaPlayerEntityFeature.STOP


### PR DESCRIPTION
# Summary

feat: show rest device favorites in sound mode list for RIoT media entity

# Testing Done

1) modified code on active HA install w/ `1.19.0` of this HACS integration
2) restarted HA
3) confirmed sound mode list of media player entity shows favorites (see below screenshot)
![Screenshot 2024-05-08 at 02 28 09](https://github.com/dahlb/ha_hatch/assets/6374067/3c7cbccb-4ff2-4e08-9f54-4966b18cc1f1)

_(**Note:** I also know this works from extensive testing of this same particular change in https://github.com/dahlb/ha_hatch/pull/121)_