### PR TITLE
Adds current favotie name as attr

### DIFF
--- a/custom_components/ha_hatch/riot_media_entity.py
+++ b/custom_components/ha_hatch/riot_media_entity.py
@@ -46,6 +46,11 @@ class RiotMediaEntity(RestEntity, MediaPlayerEntity):
             self._attr_state = STATE_IDLE
         self._attr_extra_state_attributes["current"] = self.rest_device.current_playing
         self._attr_extra_state_attributes["current_favorite"] = self.rest_device.current_id
+        self._attr_extra_state_attributes["current_favorite_name"] = next((
+            f["steps"][0]["name"] for f
+            in self.rest_device.favorites
+            if f["id"] == self.rest_device.current_id
+        ), None)
         self._attr_extra_state_attributes["current_step"] = self.rest_device.current_step
         if self.rest_device.audio_track is not None:
             self._attr_sound_mode = self.rest_device.audio_track.name


### PR DESCRIPTION
### Summary

Adds an additional attribute property to the riot media player that includes the name of the current favorite as displayed in the hatch app.

### Motivation

I would light to control other devices in the room when I change the hatch's scene. Having a stable user specified handle is convenient for ha automation/node red automations.

### Current Issues

Hatch treats the scene's id aka "current_id" / "current_favorite" as an opaque immutable value that changes anytime the scene is modified. e.g. if the scene volume / color / brightness / etc is modified the scene is replaced with a new scene with a different id which triggering on this value cumbersome.

### Solution

The proposed solution is make the value more transparent and stable by allowing the user set the key via hatch.

**Example attributes**
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/ded1c42b-3267-4740-aa0c-315548594281" />

**Example node-red routing**
<img width="746" alt="image" src="https://github.com/user-attachments/assets/f39cce00-85aa-4b24-9f7e-1ad8db0291b8" />
