### PR TITLE
feat: Restore alarm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ You can now use the following services:
   * use the alarm wake time entity to change when the alarm sound starts; the sunrise light start shifts with it
   * when Hatch omits an alarm `endTime`, wake time is derived from `startTime` plus the alarm sunrise duration
   * automations can set wake time with the built-in `time.set_value` action, for example `time: "06:45:00"`
+  * automations and Developer Tools can set repeat days with the `ha_hatch.set_alarm_weekdays` action
   * alarm changes made in the Hatch app are refreshed automatically every 10 minutes; reload the integration to see them immediately
-  * alarm creation, alarm deletion, and alarm sound/day editing are not supported
+  * alarm creation, alarm deletion, and alarm sound/light editing are not supported
 * Media player: Select sound mode
   * Possible options here are: Stream, PinkNoise, Dryer, Ocean, Wind, Rain, Bird, Crickets, Brahms, Twinkle, RockABye
 * Media player: Set volume

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A custom integration for Hatch Rest/Restore Sound Machines. This project is most
 - adjust light brightness and color
 - turn rest plus on and off
 - turn clock on and off and adjust brightness (Rest+ 2nd gen/Restore 3) 
+- enable and disable existing alarms (Restore 3)
 - turn Toddler Lock on and off (Rest+ 2nd gen) 
 - monitor device charging status (Rest+ 2nd gen)
 
@@ -48,6 +49,9 @@ If you receive an error, please go through these steps;
 You can now use the following services:
 * Rest+ 2nd gen: activate scene to start a defined favorite
   * if you add new favorites reload the integration to update available scenes or restart ha
+* Restore 3: use the alarm switch to enable or disable an existing alarm
+  * if you add or delete alarms in the Hatch app, reload the integration to update available switches or restart ha
+  * alarm time editing and alarm creation are not supported
 * Media player: Select sound mode
   * Possible options here are: Stream, PinkNoise, Dryer, Ocean, Wind, Rain, Bird, Crickets, Brahms, Twinkle, RockABye
 * Media player: Set volume

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A custom integration for Hatch Rest/Restore Sound Machines. This project is most
 - adjust light brightness and color
 - turn rest plus on and off
 - turn clock on and off and adjust brightness (Rest+ 2nd gen/Restore 3) 
-- enable and disable existing alarms (Restore 3)
+- enable and disable existing alarms (Restore, Restore 2, Restore 3)
 - turn Toddler Lock on and off (Rest+ 2nd gen) 
 - monitor device charging status (Rest+ 2nd gen)
 
@@ -49,7 +49,7 @@ If you receive an error, please go through these steps;
 You can now use the following services:
 * Rest+ 2nd gen: activate scene to start a defined favorite
   * if you add new favorites reload the integration to update available scenes or restart ha
-* Restore 3: use the alarm switch to enable or disable an existing alarm
+* Restore/Restore 2/Restore 3: use the alarm switch to enable or disable an existing alarm
   * if you add or delete alarms in the Hatch app, reload the integration to update available switches or restart ha
   * alarm time editing and alarm creation are not supported
 * Media player: Select sound mode

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A custom integration for Hatch Rest/Restore Sound Machines. This project is most
 - adjust light brightness and color
 - turn rest plus on and off
 - turn clock on and off and adjust brightness (Rest+ 2nd gen/Restore 3) 
-- enable and disable existing alarms (Restore, Restore 2, Restore 3)
+- enable, disable, and edit wake times for existing alarms (Restore, Restore 2, Restore 3)
 - turn Toddler Lock on and off (Rest+ 2nd gen) 
 - monitor device charging status (Rest+ 2nd gen)
 
@@ -50,8 +50,11 @@ You can now use the following services:
 * Rest+ 2nd gen: activate scene to start a defined favorite
   * if you add new favorites reload the integration to update available scenes or restart ha
 * Restore/Restore 2/Restore 3: use the alarm switch to enable or disable an existing alarm
+  * use the alarm wake time entity to change when the alarm sound starts; the sunrise light start shifts with it
+  * when Hatch omits an alarm `endTime`, wake time is derived from `startTime` plus the alarm sunrise duration
+  * automations can set wake time with the built-in `time.set_value` action, for example `time: "06:45:00"`
   * if you add or delete alarms in the Hatch app, reload the integration to update available switches or restart ha
-  * alarm time editing and alarm creation are not supported
+  * alarm creation, alarm deletion, and alarm sound/day editing are not supported
 * Media player: Select sound mode
   * Possible options here are: Stream, PinkNoise, Dryer, Ocean, Wind, Rain, Bird, Crickets, Brahms, Twinkle, RockABye
 * Media player: Set volume

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can now use the following services:
   * use the alarm wake time entity to change when the alarm sound starts; the sunrise light start shifts with it
   * when Hatch omits an alarm `endTime`, wake time is derived from `startTime` plus the alarm sunrise duration
   * automations can set wake time with the built-in `time.set_value` action, for example `time: "06:45:00"`
-  * if you add or delete alarms in the Hatch app, reload the integration to update available switches or restart ha
+  * alarm changes made in the Hatch app are refreshed automatically every 10 minutes; reload the integration to see them immediately
   * alarm creation, alarm deletion, and alarm sound/day editing are not supported
 * Media player: Select sound mode
   * Possible options here are: Stream, PinkNoise, Dryer, Ocean, Wind, Rain, Bird, Crickets, Brahms, Twinkle, RockABye

--- a/custom_components/ha_hatch/__init__.py
+++ b/custom_components/ha_hatch/__init__.py
@@ -33,6 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    coordinator.async_start_alarm_refresh()
 
     if not config_entry.update_listeners:
         config_entry.add_update_listener(async_update_options)

--- a/custom_components/ha_hatch/__init__.py
+++ b/custom_components/ha_hatch/__init__.py
@@ -16,6 +16,13 @@ from .hatch_data_update_coordinator import HatchDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+async def async_setup(hass: HomeAssistant, _config):
+    from .services import async_register_services
+
+    async_register_services(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     email = config_entry.data[CONF_EMAIL]

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -21,8 +21,10 @@ def alarm_base_names(alarms: list[dict[str, Any]]):
                 yield alarm_id, "Default Alarm"
                 continue
             alarm_name = str(default_alarm_count)
+            yield alarm_id, f"Alarm - {alarm_name}"
+            continue
 
-        yield alarm_id, f"Alarm - {alarm_name}"
+        yield alarm_id, f"{alarm_name} Alarm"
 
 
 def alarm_by_id(rest_device, alarm_id: int | str) -> dict[str, Any] | None:

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -109,7 +109,7 @@ def alarm_reference_from_unique_id(
     if not unique_id:
         return None
 
-    for suffix in suffixes:
+    for suffix in sorted(suffixes, key=len, reverse=True):
         if not unique_id.endswith(suffix):
             continue
         unique_id_without_suffix = unique_id[: -len(suffix)]
@@ -252,7 +252,7 @@ def _is_default_alarm_name(alarm_name: str) -> bool:
 
 def _normalize_days_of_week(days_of_week: Any) -> int | None:
     if days_of_week is None:
-        return 0
+        return None
     if isinstance(days_of_week, bool) or not isinstance(days_of_week, int):
         return None
     if days_of_week < 0 or days_of_week > ALARM_WEEKDAYS_MASK:
@@ -268,7 +268,7 @@ def _parse_alarm_datetime(value: Any) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is not None:
-        return parsed.replace(tzinfo=None)
+        return parsed.astimezone().replace(tzinfo=None)
     return parsed
 
 

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -6,22 +6,22 @@ from typing import Any
 DEFAULT_ALARM_NAME = "alarm default name"
 ALARM_UNIQUE_ID_MARKER = "_alarm_"
 ALARM_WEEKDAY_BITS: dict[str, int] = {
-    "sunday": 1,
     "monday": 2,
     "tuesday": 4,
     "wednesday": 8,
     "thursday": 16,
     "friday": 32,
     "saturday": 64,
+    "sunday": 1,
 }
 ALARM_WEEKDAY_LABELS: dict[str, str] = {
-    "sunday": "Sun",
     "monday": "Mon",
     "tuesday": "Tue",
     "wednesday": "Wed",
     "thursday": "Thu",
     "friday": "Fri",
     "saturday": "Sat",
+    "sunday": "Sun",
 }
 ALARM_WEEKDAYS_MASK = sum(ALARM_WEEKDAY_BITS.values())
 ALARM_WEEKDAYS_ONLY_MASK = (

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -5,6 +5,33 @@ from typing import Any
 
 DEFAULT_ALARM_NAME = "alarm default name"
 ALARM_UNIQUE_ID_MARKER = "_alarm_"
+ALARM_WEEKDAY_BITS: dict[str, int] = {
+    "sunday": 1,
+    "monday": 2,
+    "tuesday": 4,
+    "wednesday": 8,
+    "thursday": 16,
+    "friday": 32,
+    "saturday": 64,
+}
+ALARM_WEEKDAY_LABELS: dict[str, str] = {
+    "sunday": "Sun",
+    "monday": "Mon",
+    "tuesday": "Tue",
+    "wednesday": "Wed",
+    "thursday": "Thu",
+    "friday": "Fri",
+    "saturday": "Sat",
+}
+ALARM_WEEKDAYS_MASK = sum(ALARM_WEEKDAY_BITS.values())
+ALARM_WEEKDAYS_ONLY_MASK = (
+    ALARM_WEEKDAY_BITS["monday"]
+    | ALARM_WEEKDAY_BITS["tuesday"]
+    | ALARM_WEEKDAY_BITS["wednesday"]
+    | ALARM_WEEKDAY_BITS["thursday"]
+    | ALARM_WEEKDAY_BITS["friday"]
+)
+ALARM_WEEKENDS_MASK = ALARM_WEEKDAY_BITS["sunday"] | ALARM_WEEKDAY_BITS["saturday"]
 
 
 def alarm_base_names(alarms: list[dict[str, Any]]):
@@ -75,6 +102,88 @@ def alarm_unique_id_prefix(thing_name: str) -> str:
     return f"{thing_name}{ALARM_UNIQUE_ID_MARKER}"
 
 
+def alarm_reference_from_unique_id(
+    unique_id: str | None,
+    suffixes: set[str],
+) -> tuple[str, str] | None:
+    if not unique_id:
+        return None
+
+    for suffix in suffixes:
+        if not unique_id.endswith(suffix):
+            continue
+        unique_id_without_suffix = unique_id[: -len(suffix)]
+        thing_name, marker, alarm_id = unique_id_without_suffix.rpartition(
+            ALARM_UNIQUE_ID_MARKER
+        )
+        if marker and thing_name and alarm_id:
+            return thing_name, alarm_id
+
+    return None
+
+
+def alarm_repeat_attributes(alarm: dict[str, Any] | None) -> dict[str, Any]:
+    if alarm is None:
+        return {}
+
+    days_of_week = alarm.get("daysOfWeek")
+    return {
+        "repeat": alarm_repeat_label(days_of_week),
+        "weekdays": alarm_weekdays(days_of_week),
+        "days_of_week": days_of_week,
+    }
+
+
+def alarm_weekdays(days_of_week: Any) -> list[str]:
+    normalized_days_of_week = _normalize_days_of_week(days_of_week)
+    if normalized_days_of_week is None:
+        return []
+    return [
+        weekday
+        for weekday, bit in ALARM_WEEKDAY_BITS.items()
+        if normalized_days_of_week & bit
+    ]
+
+
+def alarm_repeat_label(days_of_week: Any) -> str:
+    normalized_days_of_week = _normalize_days_of_week(days_of_week)
+    if normalized_days_of_week is None:
+        return "Unknown"
+    if normalized_days_of_week == 0:
+        return "Once"
+    if normalized_days_of_week == ALARM_WEEKDAYS_ONLY_MASK:
+        return "Weekdays"
+    if normalized_days_of_week == ALARM_WEEKENDS_MASK:
+        return "Weekends"
+    if normalized_days_of_week == ALARM_WEEKDAYS_MASK:
+        return "Every day"
+    return ", ".join(
+        ALARM_WEEKDAY_LABELS[weekday]
+        for weekday in alarm_weekdays(normalized_days_of_week)
+    )
+
+
+def normalize_alarm_weekdays(weekdays: Any) -> list[str]:
+    if weekdays is None:
+        return []
+    if isinstance(weekdays, str):
+        weekdays = [weekdays]
+
+    normalized_weekdays = []
+    try:
+        weekday_values = iter(weekdays)
+    except TypeError as error:
+        raise ValueError("Alarm weekdays must be a list of weekday names") from error
+
+    for weekday in weekday_values:
+        normalized_weekday = str(weekday).strip().lower()
+        if normalized_weekday not in ALARM_WEEKDAY_BITS:
+            raise ValueError(f"Unsupported alarm weekday: {weekday}")
+        normalized_weekdays.append(normalized_weekday)
+
+    return normalized_weekdays
+
+
 def remove_stale_alarm_entities(
     hass,
     config_entry,
@@ -139,6 +248,16 @@ def _clean_alarm_name(alarm_name: Any) -> str:
 
 def _is_default_alarm_name(alarm_name: str) -> bool:
     return alarm_name.lower() in {"", "default", DEFAULT_ALARM_NAME}
+
+
+def _normalize_days_of_week(days_of_week: Any) -> int | None:
+    if days_of_week is None:
+        return 0
+    if isinstance(days_of_week, bool) or not isinstance(days_of_week, int):
+        return None
+    if days_of_week < 0 or days_of_week > ALARM_WEEKDAYS_MASK:
+        return None
+    return days_of_week
 
 
 def _parse_alarm_datetime(value: Any) -> datetime | None:

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+from typing import Any
+
+DEFAULT_ALARM_NAME = "alarm default name"
+ALARM_UNIQUE_ID_MARKER = "_alarm_"
+
+
+def alarm_base_names(alarms: list[dict[str, Any]]):
+    default_alarm_count = 0
+    for alarm in alarms:
+        alarm_id = alarm.get("id")
+        if alarm_id is None:
+            continue
+
+        alarm_name = _clean_alarm_name(alarm.get("name"))
+        if _is_default_alarm_name(alarm_name):
+            default_alarm_count += 1
+            alarm_name = "Default" if default_alarm_count == 1 else str(default_alarm_count)
+
+        yield alarm_id, f"Alarm - {alarm_name}"
+
+
+def alarm_by_id(rest_device, alarm_id: int | str) -> dict[str, Any] | None:
+    get_alarm_by_id = getattr(rest_device, "alarm_by_id", None)
+    if callable(get_alarm_by_id):
+        return get_alarm_by_id(alarm_id)
+
+    alarm_id_string = str(alarm_id)
+    return next(
+        (
+            alarm
+            for alarm in getattr(rest_device, "alarms", [])
+            if str(alarm.get("id")) == alarm_id_string
+        ),
+        None,
+    )
+
+
+def alarm_wake_time(alarm: dict[str, Any] | None) -> time | None:
+    if alarm is None:
+        return None
+    parsed_start_time = _parse_alarm_datetime(alarm.get("startTime"))
+    parsed_end_time = _parse_alarm_datetime(alarm.get("endTime"))
+    if parsed_start_time is None:
+        return None
+    if parsed_end_time is not None:
+        return parsed_end_time.time()
+    if alarm.get("endTime") is None:
+        sunrise_duration = _alarm_sunrise_duration_seconds(alarm)
+        if sunrise_duration is not None:
+            return (parsed_start_time + timedelta(seconds=sunrise_duration)).time()
+    return None
+
+
+def alarm_has_valid_wake_times(alarm: dict[str, Any]) -> bool:
+    if _parse_alarm_datetime(alarm.get("startTime")) is None:
+        return False
+    if alarm.get("endTime") is None:
+        return _alarm_sunrise_duration_seconds(alarm) is not None
+    return _parse_alarm_datetime(alarm.get("endTime")) is not None
+
+
+def alarm_unique_id(thing_name: str, alarm_id: int | str, suffix: str) -> str:
+    return f"{alarm_unique_id_prefix(thing_name)}{alarm_id}{suffix}"
+
+
+def alarm_unique_id_prefix(thing_name: str) -> str:
+    return f"{thing_name}{ALARM_UNIQUE_ID_MARKER}"
+
+
+def remove_stale_alarm_entities(
+    hass,
+    config_entry,
+    domain: str,
+    current_alarm_unique_ids: set[str],
+    authoritative_alarm_unique_id_prefixes: set[str],
+    unique_id_suffix: str,
+) -> None:
+    if not authoritative_alarm_unique_id_prefixes:
+        return
+
+    from homeassistant.helpers import entity_registry as er
+
+    entity_registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(
+        entity_registry,
+        config_entry.entry_id,
+    ):
+        if entry.domain != domain:
+            continue
+        if entry.unique_id in current_alarm_unique_ids:
+            continue
+        if _is_alarm_unique_id_for_authoritative_device(
+            entry.unique_id,
+            authoritative_alarm_unique_id_prefixes,
+            unique_id_suffix,
+        ):
+            entity_registry.async_remove(entry.entity_id)
+
+
+def _clean_alarm_name(alarm_name: Any) -> str:
+    if alarm_name is None:
+        return ""
+    return " ".join(str(alarm_name).replace("_", " ").split())
+
+
+def _is_default_alarm_name(alarm_name: str) -> bool:
+    return alarm_name.lower() in {"", "default", DEFAULT_ALARM_NAME}
+
+
+def _parse_alarm_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        return parsed.replace(tzinfo=None)
+    return parsed
+
+
+def _alarm_sunrise_duration_seconds(alarm: dict[str, Any]) -> int | None:
+    steps = alarm.get("steps") or []
+    sunrise_step_duration = next(
+        (
+            duration
+            for step in steps
+            if isinstance(step, dict)
+            and str(step.get("name", "")).lower() == "sunrise"
+            and (duration := _step_color_duration_seconds(step)) is not None
+        ),
+        None,
+    )
+    if sunrise_step_duration is not None:
+        return sunrise_step_duration
+
+    return next(
+        (
+            duration
+            for step in steps
+            if isinstance(step, dict)
+            and (duration := _step_color_duration_seconds(step)) is not None
+        ),
+        None,
+    )
+
+
+def _step_color_duration_seconds(step: dict[str, Any]) -> int | None:
+    if step.get("enabled") is False:
+        return None
+
+    color = step.get("color")
+    if not isinstance(color, dict) or color.get("ignore") is True:
+        return None
+
+    duration = color.get("duration")
+    if isinstance(duration, bool) or not isinstance(duration, int) or duration <= 0:
+        return None
+
+    return duration
+
+
+def _is_alarm_unique_id_for_authoritative_device(
+    unique_id: str,
+    authoritative_alarm_unique_id_prefixes: set[str],
+    unique_id_suffix: str,
+) -> bool:
+    return unique_id.endswith(unique_id_suffix) and any(
+        unique_id.startswith(prefix)
+        for prefix in authoritative_alarm_unique_id_prefixes
+    )

--- a/custom_components/ha_hatch/alarm.py
+++ b/custom_components/ha_hatch/alarm.py
@@ -17,7 +17,10 @@ def alarm_base_names(alarms: list[dict[str, Any]]):
         alarm_name = _clean_alarm_name(alarm.get("name"))
         if _is_default_alarm_name(alarm_name):
             default_alarm_count += 1
-            alarm_name = "Default" if default_alarm_count == 1 else str(default_alarm_count)
+            if default_alarm_count == 1:
+                yield alarm_id, "Default Alarm"
+                continue
+            alarm_name = str(default_alarm_count)
 
         yield alarm_id, f"Alarm - {alarm_name}"
 
@@ -98,6 +101,32 @@ def remove_stale_alarm_entities(
             unique_id_suffix,
         ):
             entity_registry.async_remove(entry.entity_id)
+
+
+def update_alarm_entity_names(
+    hass,
+    config_entry,
+    domain: str,
+    current_alarm_names: dict[str, str],
+) -> None:
+    if not current_alarm_names:
+        return
+
+    from homeassistant.helpers import entity_registry as er
+
+    entity_registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(
+        entity_registry,
+        config_entry.entry_id,
+    ):
+        alarm_name = current_alarm_names.get(entry.unique_id)
+        if entry.domain != domain or alarm_name is None:
+            continue
+        if entry.original_name != alarm_name:
+            entity_registry.async_update_entity(
+                entry.entity_id,
+                original_name=alarm_name,
+            )
 
 
 def _clean_alarm_name(alarm_name: Any) -> str:

--- a/custom_components/ha_hatch/const.py
+++ b/custom_components/ha_hatch/const.py
@@ -16,4 +16,5 @@ PLATFORMS = [
     Platform.SCENE,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]

--- a/custom_components/ha_hatch/hatch_data_update_coordinator.py
+++ b/custom_components/ha_hatch/hatch_data_update_coordinator.py
@@ -93,7 +93,13 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         return remove_callback
 
     async def _async_handle_alarm_refresh_interval(self, now: datetime) -> None:
-        await self.async_refresh_alarms()
+        try:
+            await self.async_refresh_alarms()
+        except Exception as error:
+            _LOGGER.exception(
+                "Unhandled error during scheduled Hatch alarm refresh",
+                exc_info=error,
+            )
 
     async def async_refresh_alarms(self) -> None:
         alarm_devices = [
@@ -130,9 +136,15 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_notify_alarm_refresh_callbacks(self) -> None:
         for callback in tuple(self._alarm_refresh_callbacks):
-            result = callback()
-            if isawaitable(result):
-                await result
+            try:
+                result = callback()
+                if isawaitable(result):
+                    await result
+            except Exception as error:
+                _LOGGER.exception(
+                    "Hatch alarm refresh callback failed",
+                    exc_info=error,
+                )
 
     def _clear_retry_backoff(self) -> None:
         self._retry_backoff_until.pop(self.email, None)
@@ -229,6 +241,8 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self._clear_retry_backoff()
             for rest_device in self.rest_devices:
                 rest_device.register_callback(self.async_update_listeners)
+            # Re-login replaces every RestDevice instance, so alarm-derived entities
+            # must reconcile against the new objects to keep references current.
             await self._async_notify_alarm_refresh_callbacks()
             return [rest_device.__repr__() for rest_device in self.rest_devices]
         except AuthError as error:

--- a/custom_components/ha_hatch/hatch_data_update_coordinator.py
+++ b/custom_components/ha_hatch/hatch_data_update_coordinator.py
@@ -1,4 +1,7 @@
+import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import timedelta, UTC, datetime
+from inspect import isawaitable
 from logging import getLogger, Logger
 import traceback
 from typing import Final
@@ -9,12 +12,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from custom_components.ha_hatch import DOMAIN
 
 _LOGGER: Logger = getLogger(__name__)
 
+ALARM_REFRESH_INTERVAL: Final = timedelta(minutes=10)
 DEFAULT_RETRY_INTERVAL: Final = timedelta(minutes=1)
 RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(minutes=15)
 MAX_RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(hours=6)
@@ -22,6 +27,7 @@ AWSCRT_MISMATCH_RETRY_INTERVAL: Final = timedelta(hours=1)
 MAX_AWSCRT_MISMATCH_RETRY_INTERVAL: Final = timedelta(hours=12)
 AWSCRT_MISMATCH_TRACE_FILE: Final = "awscrt/mqtt.py"
 AWSCRT_MISMATCH_TRACE_NAME: Final = "connect"
+AlarmRefreshCallback = Callable[[], Awaitable[None] | None]
 
 
 class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
@@ -42,6 +48,9 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         """Initialize the device."""
         self.email: str = email
         self.password: str = password
+        self._alarm_refresh_callbacks: set[AlarmRefreshCallback] = set()
+        self._alarm_refresh_lock = asyncio.Lock()
+        self._alarm_refresh_unsub: Callable[[], None] | None = None
 
         super().__init__(
             hass,
@@ -61,6 +70,66 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
     def _rest_device_unsub(self) -> None:
         for rest_device in self.rest_devices:
             rest_device.remove_callback(self.async_update_listeners)
+
+    def async_start_alarm_refresh(self) -> None:
+        if self._alarm_refresh_unsub is not None:
+            return
+
+        self._alarm_refresh_unsub = async_track_time_interval(
+            self.hass,
+            self._async_handle_alarm_refresh_interval,
+            ALARM_REFRESH_INTERVAL,
+        )
+
+    def async_add_alarm_refresh_callback(
+        self,
+        callback: AlarmRefreshCallback,
+    ) -> Callable[[], None]:
+        self._alarm_refresh_callbacks.add(callback)
+
+        def remove_callback() -> None:
+            self._alarm_refresh_callbacks.discard(callback)
+
+        return remove_callback
+
+    async def _async_handle_alarm_refresh_interval(self, now: datetime) -> None:
+        await self.async_refresh_alarms()
+
+    async def async_refresh_alarms(self) -> None:
+        alarm_devices = [
+            rest_device
+            for rest_device in self.rest_devices
+            if getattr(rest_device, "alarms_loaded", False)
+            and callable(getattr(rest_device, "refresh_alarms", None))
+        ]
+        if not alarm_devices:
+            return
+
+        async with self._alarm_refresh_lock:
+            refresh_results = await asyncio.gather(
+                *(rest_device.refresh_alarms() for rest_device in alarm_devices),
+                return_exceptions=True,
+            )
+
+        refreshed = False
+        for rest_device, result in zip(alarm_devices, refresh_results, strict=True):
+            if isinstance(result, Exception):
+                _LOGGER.warning(
+                    "Failed to refresh Hatch alarms for %s",
+                    rest_device.device_name,
+                    exc_info=result,
+                )
+                continue
+            refreshed = True
+
+        if refreshed:
+            await self._async_notify_alarm_refresh_callbacks()
+
+    async def _async_notify_alarm_refresh_callbacks(self) -> None:
+        for callback in tuple(self._alarm_refresh_callbacks):
+            result = callback()
+            if isawaitable(result):
+                await result
 
     def _clear_retry_backoff(self) -> None:
         self._retry_backoff_until.pop(self.email, None)
@@ -157,6 +226,7 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self._clear_retry_backoff()
             for rest_device in self.rest_devices:
                 rest_device.register_callback(self.async_update_listeners)
+            await self._async_notify_alarm_refresh_callbacks()
             return [rest_device.__repr__() for rest_device in self.rest_devices]
         except AuthError as error:
             self._clear_retry_backoff()
@@ -195,6 +265,10 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
 
     async def async_shutdown(self) -> None:
         """Cancel any scheduled call, and ignore new runs."""
+        if self._alarm_refresh_unsub is not None:
+            self._alarm_refresh_unsub()
+            self._alarm_refresh_unsub = None
+        self._alarm_refresh_callbacks.clear()
         self._disconnect_mqtt()
         self._rest_device_unsub()
         await super().async_shutdown()

--- a/custom_components/ha_hatch/hatch_data_update_coordinator.py
+++ b/custom_components/ha_hatch/hatch_data_update_coordinator.py
@@ -99,7 +99,10 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         alarm_devices = [
             rest_device
             for rest_device in self.rest_devices
-            if getattr(rest_device, "alarms_loaded", False)
+            if (
+                getattr(rest_device, "alarm_capable", False)
+                or getattr(rest_device, "alarms_loaded", False)
+            )
             and callable(getattr(rest_device, "refresh_alarms", None))
         ]
         if not alarm_devices:

--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
   "loggers": ["ha_hatch", "hatch_rest_api"],
   "requirements": ["hatch_rest_api==1.33.0"],
-  "version": "1.28.3"
+  "version": "1.29.0"
 }

--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
   "loggers": ["ha_hatch", "hatch_rest_api"],
-  "requirements": ["hatch_rest_api==1.32.1"],
+  "requirements": ["hatch_rest_api==1.33.0"],
   "version": "1.28.3"
 }

--- a/custom_components/ha_hatch/sensor.py
+++ b/custom_components/ha_hatch/sensor.py
@@ -179,7 +179,7 @@ class HatchAlarmRepeat(HatchEntity, SensorEntity):
             return
         self._attr_name = alarm_name
         if getattr(self, "hass", None) is not None:
-            self.async_write_ha_state()
+            self.schedule_update_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/ha_hatch/sensor.py
+++ b/custom_components/ha_hatch/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -14,10 +15,21 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import HatchDataUpdateCoordinator
+from .alarm import (
+    alarm_base_names,
+    alarm_by_id,
+    alarm_repeat_attributes,
+    alarm_repeat_label,
+    alarm_unique_id,
+    alarm_unique_id_prefix,
+    remove_stale_alarm_entities,
+    update_alarm_entity_names,
+)
 from .const import DOMAIN
 from .hatch_entity import HatchEntity
 
 _LOGGER = logging.getLogger(__name__)
+ALARM_REPEAT_UNIQUE_ID_SUFFIX = "_repeat"
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
@@ -31,6 +43,69 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         if isinstance(rest_device, RestIot):
             sensor_entities.append(HatchCharging(coordinator=coordinator, thing_name=rest_device.thing_name))
     async_add_entities(sensor_entities)
+
+    alarm_entities_by_unique_id: dict[str, HatchAlarmRepeat] = {}
+
+    async def async_reconcile_alarm_entities() -> None:
+        new_alarm_entities = []
+        current_alarm_unique_ids = set()
+        current_alarm_names = {}
+        authoritative_alarm_unique_id_prefixes = set()
+        for rest_device in coordinator.rest_devices:
+            if getattr(rest_device, "alarms_loaded", False):
+                authoritative_alarm_unique_id_prefixes.add(
+                    alarm_unique_id_prefix(rest_device.thing_name)
+                )
+            for alarm_id, alarm_name in alarm_base_names(
+                getattr(rest_device, "alarms", [])
+            ):
+                unique_id = alarm_unique_id(
+                    rest_device.thing_name,
+                    alarm_id,
+                    ALARM_REPEAT_UNIQUE_ID_SUFFIX,
+                )
+                repeat_name = f"{alarm_name} Repeat"
+                current_alarm_unique_ids.add(unique_id)
+                current_alarm_names[unique_id] = repeat_name
+                if alarm_entity := alarm_entities_by_unique_id.get(unique_id):
+                    alarm_entity.update_alarm_name(repeat_name)
+                    continue
+
+                alarm_entity = HatchAlarmRepeat(
+                    coordinator=coordinator,
+                    thing_name=rest_device.thing_name,
+                    alarm_id=alarm_id,
+                    alarm_name=repeat_name,
+                    unique_id=unique_id,
+                )
+                alarm_entities_by_unique_id[unique_id] = alarm_entity
+                new_alarm_entities.append(alarm_entity)
+
+        for unique_id in set(alarm_entities_by_unique_id) - current_alarm_unique_ids:
+            alarm_entity = alarm_entities_by_unique_id.pop(unique_id)
+            await alarm_entity.async_remove(force_remove=True)
+
+        remove_stale_alarm_entities(
+            hass=hass,
+            config_entry=config_entry,
+            domain="sensor",
+            current_alarm_unique_ids=current_alarm_unique_ids,
+            authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+            unique_id_suffix=ALARM_REPEAT_UNIQUE_ID_SUFFIX,
+        )
+        update_alarm_entity_names(
+            hass=hass,
+            config_entry=config_entry,
+            domain="sensor",
+            current_alarm_names=current_alarm_names,
+        )
+        if new_alarm_entities:
+            async_add_entities(new_alarm_entities)
+
+    await async_reconcile_alarm_entities()
+    config_entry.async_on_unload(
+        coordinator.async_add_alarm_refresh_callback(async_reconcile_alarm_entities)
+    )
 
 
 class HatchBattery(HatchEntity, SensorEntity):
@@ -73,3 +148,54 @@ class HatchCharging(HatchEntity, SensorEntity):
             return "mdi:power-plug-off"
         else:
             return self.entity_description.icon
+
+
+class HatchAlarmRepeat(HatchEntity, SensorEntity):
+    entity_description = SensorEntityDescription(
+        key="alarm-repeat",
+        icon="mdi:calendar-week",
+    )
+
+    def __init__(
+        self,
+        coordinator: HatchDataUpdateCoordinator,
+        thing_name: str,
+        alarm_id: int | str,
+        alarm_name: str,
+        unique_id: str,
+    ):
+        self._alarm_id = alarm_id
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Alarm",
+        )
+        self._attr_unique_id = unique_id
+        self._attr_has_entity_name = True
+        self._attr_name = alarm_name
+
+    def update_alarm_name(self, alarm_name: str) -> None:
+        if self._attr_name == alarm_name:
+            return
+        self._attr_name = alarm_name
+        if getattr(self, "hass", None) is not None:
+            self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return self._alarm is not None
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        alarm = self._alarm
+        if alarm is None:
+            return None
+        return alarm_repeat_label(alarm.get("daysOfWeek"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return alarm_repeat_attributes(self._alarm)
+
+    @property
+    def _alarm(self) -> dict[str, Any] | None:
+        return alarm_by_id(self.rest_device, self._alarm_id)

--- a/custom_components/ha_hatch/services.py
+++ b/custom_components/ha_hatch/services.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.service import async_extract_referenced_entity_ids
 
 from .alarm import (
     alarm_reference_from_unique_id,
@@ -81,36 +82,62 @@ def _alarm_targets_from_service_call(
     entity_registry = er.async_get(hass)
     targets: dict[tuple[str, str], tuple[Any, str]] = {}
 
-    for entity_id in _service_call_entity_ids(call):
-        entry = entity_registry.async_get(entity_id)
-        if entry is None or entry.platform != DOMAIN:
-            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
+    selected = async_extract_referenced_entity_ids(hass, call, expand_group=True)
 
-        alarm_reference = alarm_reference_from_unique_id(
-            entry.unique_id,
-            ALARM_SERVICE_UNIQUE_ID_SUFFIXES,
+    for entity_id in selected.referenced:
+        target = _alarm_target_from_entity_id(
+            entity_registry,
+            coordinator,
+            entity_id,
+            raise_if_not_alarm=True,
         )
-        if alarm_reference is None:
-            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
+        if target is not None:
+            key, value = target
+            targets[key] = value
 
-        thing_name, alarm_id = alarm_reference
-        rest_device = coordinator.rest_device_by_thing_name(thing_name)
-        if rest_device is None:
-            raise ServiceValidationError(
-                f"{entity_id} belongs to a Hatch device that is not loaded"
-            )
-        targets[(thing_name, alarm_id)] = (rest_device, alarm_id)
+    for entity_id in selected.indirectly_referenced:
+        target = _alarm_target_from_entity_id(
+            entity_registry,
+            coordinator,
+            entity_id,
+            raise_if_not_alarm=False,
+        )
+        if target is not None:
+            key, value = target
+            targets[key] = value
 
     return targets
 
 
-def _service_call_entity_ids(call: ServiceCall) -> set[str]:
-    entity_ids: set[str] = set()
-    if entity_id := call.data.get(ATTR_ENTITY_ID):
-        entity_ids.update(cv.entity_ids(entity_id))
+def _alarm_target_from_entity_id(
+    entity_registry: er.EntityRegistry,
+    coordinator: HatchDataUpdateCoordinator,
+    entity_id: str,
+    *,
+    raise_if_not_alarm: bool,
+) -> tuple[tuple[str, str], tuple[Any, str]] | None:
+    entry = entity_registry.async_get(entity_id)
+    if entry is None or entry.platform != DOMAIN:
+        if raise_if_not_alarm:
+            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
+        return None
 
-    target = getattr(call, "target", None)
-    if isinstance(target, dict) and (target_entity_id := target.get(ATTR_ENTITY_ID)):
-        entity_ids.update(cv.entity_ids(target_entity_id))
+    alarm_reference = alarm_reference_from_unique_id(
+        entry.unique_id,
+        ALARM_SERVICE_UNIQUE_ID_SUFFIXES,
+    )
+    if alarm_reference is None:
+        if raise_if_not_alarm:
+            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
+        return None
 
-    return entity_ids
+    thing_name, alarm_id = alarm_reference
+    rest_device = coordinator.rest_device_by_thing_name(thing_name)
+    if rest_device is None:
+        if raise_if_not_alarm:
+            raise ServiceValidationError(
+                f"{entity_id} belongs to a Hatch device that is not loaded"
+            )
+        return None
+
+    return (thing_name, alarm_id), (rest_device, alarm_id)

--- a/custom_components/ha_hatch/services.py
+++ b/custom_components/ha_hatch/services.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
+
+from .alarm import (
+    alarm_reference_from_unique_id,
+    normalize_alarm_weekdays,
+)
+from .const import DOMAIN
+from .hatch_data_update_coordinator import HatchDataUpdateCoordinator
+
+ATTR_WEEKDAYS = "weekdays"
+SERVICE_SET_ALARM_WEEKDAYS = "set_alarm_weekdays"
+ALARM_SERVICE_UNIQUE_ID_SUFFIXES = {"_switch", "_wake_time"}
+
+
+def async_register_services(hass: HomeAssistant) -> None:
+    if hass.services.has_service(DOMAIN, SERVICE_SET_ALARM_WEEKDAYS):
+        return
+
+    async def async_set_alarm_weekdays(call: ServiceCall) -> None:
+        await _async_set_alarm_weekdays(hass, call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_ALARM_WEEKDAYS,
+        async_set_alarm_weekdays,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_WEEKDAYS): _validate_weekdays,
+                vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+            }
+        ),
+    )
+
+
+def _validate_weekdays(value: Any) -> list[str]:
+    try:
+        return normalize_alarm_weekdays(value)
+    except ValueError as error:
+        raise vol.Invalid(str(error)) from error
+
+
+async def _async_set_alarm_weekdays(
+    hass: HomeAssistant,
+    call: ServiceCall,
+) -> None:
+    coordinator = hass.data.get(DOMAIN)
+    if not isinstance(coordinator, HatchDataUpdateCoordinator):
+        raise HomeAssistantError("Hatch integration is not loaded")
+
+    alarm_targets = _alarm_targets_from_service_call(hass, coordinator, call)
+    if not alarm_targets:
+        raise HomeAssistantError("Target at least one Hatch alarm entity")
+
+    weekdays = call.data[ATTR_WEEKDAYS]
+    for rest_device, alarm_id in alarm_targets.values():
+        set_alarm_weekdays = getattr(rest_device, "set_alarm_weekdays", None)
+        if not callable(set_alarm_weekdays):
+            raise HomeAssistantError(
+                f"{rest_device.device_name} does not support alarm weekdays"
+            )
+        await set_alarm_weekdays(alarm_id, weekdays)
+
+
+def _alarm_targets_from_service_call(
+    hass: HomeAssistant,
+    coordinator: HatchDataUpdateCoordinator,
+    call: ServiceCall,
+) -> dict[tuple[str, str], tuple[Any, str]]:
+    entity_registry = er.async_get(hass)
+    targets: dict[tuple[str, str], tuple[Any, str]] = {}
+
+    for entity_id in _service_call_entity_ids(call):
+        entry = entity_registry.async_get(entity_id)
+        if entry is None or entry.platform != DOMAIN:
+            raise HomeAssistantError(f"{entity_id} is not a Hatch alarm entity")
+
+        alarm_reference = alarm_reference_from_unique_id(
+            entry.unique_id,
+            ALARM_SERVICE_UNIQUE_ID_SUFFIXES,
+        )
+        if alarm_reference is None:
+            raise HomeAssistantError(f"{entity_id} is not a Hatch alarm entity")
+
+        thing_name, alarm_id = alarm_reference
+        rest_device = coordinator.rest_device_by_thing_name(thing_name)
+        if rest_device is None:
+            raise HomeAssistantError(
+                f"{entity_id} belongs to a Hatch device that is not loaded"
+            )
+        targets[(thing_name, alarm_id)] = (rest_device, alarm_id)
+
+    return targets
+
+
+def _service_call_entity_ids(call: ServiceCall) -> set[str]:
+    entity_ids: set[str] = set()
+    if entity_id := call.data.get(ATTR_ENTITY_ID):
+        entity_ids.update(cv.entity_ids(entity_id))
+
+    target = getattr(call, "target", None)
+    if isinstance(target, dict) and (target_entity_id := target.get(ATTR_ENTITY_ID)):
+        entity_ids.update(cv.entity_ids(target_entity_id))
+
+    return entity_ids

--- a/custom_components/ha_hatch/services.py
+++ b/custom_components/ha_hatch/services.py
@@ -5,7 +5,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 
@@ -18,7 +18,7 @@ from .hatch_data_update_coordinator import HatchDataUpdateCoordinator
 
 ATTR_WEEKDAYS = "weekdays"
 SERVICE_SET_ALARM_WEEKDAYS = "set_alarm_weekdays"
-ALARM_SERVICE_UNIQUE_ID_SUFFIXES = {"_switch", "_wake_time"}
+ALARM_SERVICE_UNIQUE_ID_SUFFIXES = {"_switch"}
 
 
 def async_register_services(hass: HomeAssistant) -> None:
@@ -35,7 +35,10 @@ def async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Required(ATTR_WEEKDAYS): _validate_weekdays,
-                vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                vol.Optional(ATTR_ENTITY_ID): vol.All(
+                    cv.entity_ids,
+                    [cv.entity_domain("switch")],
+                ),
             }
         ),
     )
@@ -58,13 +61,13 @@ async def _async_set_alarm_weekdays(
 
     alarm_targets = _alarm_targets_from_service_call(hass, coordinator, call)
     if not alarm_targets:
-        raise HomeAssistantError("Target at least one Hatch alarm entity")
+        raise ServiceValidationError("Target at least one Hatch alarm entity")
 
     weekdays = call.data[ATTR_WEEKDAYS]
     for rest_device, alarm_id in alarm_targets.values():
         set_alarm_weekdays = getattr(rest_device, "set_alarm_weekdays", None)
         if not callable(set_alarm_weekdays):
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 f"{rest_device.device_name} does not support alarm weekdays"
             )
         await set_alarm_weekdays(alarm_id, weekdays)
@@ -81,19 +84,19 @@ def _alarm_targets_from_service_call(
     for entity_id in _service_call_entity_ids(call):
         entry = entity_registry.async_get(entity_id)
         if entry is None or entry.platform != DOMAIN:
-            raise HomeAssistantError(f"{entity_id} is not a Hatch alarm entity")
+            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
 
         alarm_reference = alarm_reference_from_unique_id(
             entry.unique_id,
             ALARM_SERVICE_UNIQUE_ID_SUFFIXES,
         )
         if alarm_reference is None:
-            raise HomeAssistantError(f"{entity_id} is not a Hatch alarm entity")
+            raise ServiceValidationError(f"{entity_id} is not a Hatch alarm entity")
 
         thing_name, alarm_id = alarm_reference
         rest_device = coordinator.rest_device_by_thing_name(thing_name)
         if rest_device is None:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 f"{entity_id} belongs to a Hatch device that is not loaded"
             )
         targets[(thing_name, alarm_id)] = (rest_device, alarm_id)

--- a/custom_components/ha_hatch/services.py
+++ b/custom_components/ha_hatch/services.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.service import async_extract_referenced_entity_ids
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
 
 from .alarm import (
     alarm_reference_from_unique_id,
@@ -33,14 +35,8 @@ def async_register_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_SET_ALARM_WEEKDAYS,
         async_set_alarm_weekdays,
-        schema=vol.Schema(
-            {
-                vol.Required(ATTR_WEEKDAYS): _validate_weekdays,
-                vol.Optional(ATTR_ENTITY_ID): vol.All(
-                    cv.entity_ids,
-                    [cv.entity_domain("switch")],
-                ),
-            }
+        schema=cv.make_entity_service_schema(
+            {vol.Optional(ATTR_WEEKDAYS, default=list): _validate_weekdays}
         ),
     )
 
@@ -64,14 +60,15 @@ async def _async_set_alarm_weekdays(
     if not alarm_targets:
         raise ServiceValidationError("Target at least one Hatch alarm entity")
 
-    weekdays = call.data[ATTR_WEEKDAYS]
-    for rest_device, alarm_id in alarm_targets.values():
-        set_alarm_weekdays = getattr(rest_device, "set_alarm_weekdays", None)
-        if not callable(set_alarm_weekdays):
+    for rest_device, _alarm_id in alarm_targets.values():
+        if not callable(getattr(rest_device, "set_alarm_weekdays", None)):
             raise ServiceValidationError(
                 f"{rest_device.device_name} does not support alarm weekdays"
             )
-        await set_alarm_weekdays(alarm_id, weekdays)
+
+    weekdays = call.data[ATTR_WEEKDAYS]
+    for rest_device, alarm_id in alarm_targets.values():
+        await rest_device.set_alarm_weekdays(alarm_id, weekdays)
 
 
 def _alarm_targets_from_service_call(
@@ -82,7 +79,9 @@ def _alarm_targets_from_service_call(
     entity_registry = er.async_get(hass)
     targets: dict[tuple[str, str], tuple[Any, str]] = {}
 
-    selected = async_extract_referenced_entity_ids(hass, call, expand_group=True)
+    selected = async_extract_referenced_entity_ids(
+        hass, TargetSelection(call.data), expand_group=True
+    )
 
     for entity_id in selected.referenced:
         target = _alarm_target_from_entity_id(

--- a/custom_components/ha_hatch/services.yaml
+++ b/custom_components/ha_hatch/services.yaml
@@ -4,9 +4,7 @@ set_alarm_weekdays:
   target:
     entity:
       integration: ha_hatch
-      domain:
-        - switch
-        - time
+      domain: switch
   fields:
     weekdays:
       name: Weekdays
@@ -15,10 +13,9 @@ set_alarm_weekdays:
       selector:
         select:
           multiple: true
-          mode: dropdown
+          mode: list
+          sort: false
           options:
-            - label: Sunday
-              value: sunday
             - label: Monday
               value: monday
             - label: Tuesday
@@ -31,3 +28,5 @@ set_alarm_weekdays:
               value: friday
             - label: Saturday
               value: saturday
+            - label: Sunday
+              value: sunday

--- a/custom_components/ha_hatch/services.yaml
+++ b/custom_components/ha_hatch/services.yaml
@@ -9,7 +9,7 @@ set_alarm_weekdays:
     weekdays:
       name: Weekdays
       description: Weekdays when the alarm should repeat.
-      required: true
+      required: false
       selector:
         select:
           multiple: true

--- a/custom_components/ha_hatch/services.yaml
+++ b/custom_components/ha_hatch/services.yaml
@@ -1,0 +1,33 @@
+set_alarm_weekdays:
+  name: Set alarm weekdays
+  description: Set which weekdays a Hatch alarm repeats on. Use an empty weekday list for a one-time alarm.
+  target:
+    entity:
+      integration: ha_hatch
+      domain:
+        - switch
+        - time
+  fields:
+    weekdays:
+      name: Weekdays
+      description: Weekdays when the alarm should repeat.
+      required: true
+      selector:
+        select:
+          multiple: true
+          mode: dropdown
+          options:
+            - label: Sunday
+              value: sunday
+            - label: Monday
+              value: monday
+            - label: Tuesday
+              value: tuesday
+            - label: Wednesday
+              value: wednesday
+            - label: Thursday
+              value: thursday
+            - label: Friday
+              value: friday
+            - label: Saturday
+              value: saturday

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -16,6 +16,7 @@ from . import HatchDataUpdateCoordinator
 from .alarm import (
     alarm_base_names,
     alarm_by_id,
+    alarm_repeat_attributes,
     alarm_unique_id,
     alarm_unique_id_prefix,
     remove_stale_alarm_entities,
@@ -201,6 +202,10 @@ class HatchAlarmSwitch(HatchEntity, SwitchEntity):
         if alarm is None:
             return None
         return bool(alarm.get("enabled"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return alarm_repeat_attributes(self._alarm)
 
     async def async_turn_on(self, **kwargs):
         await self._async_set_enabled(True)

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -19,6 +19,7 @@ from .alarm import (
     alarm_unique_id,
     alarm_unique_id_prefix,
     remove_stale_alarm_entities,
+    update_alarm_entity_names,
 )
 from .const import DOMAIN
 from .hatch_entity import HatchEntity
@@ -31,6 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
     entities = []
     current_alarm_unique_ids = set()
+    current_alarm_names = {}
     authoritative_alarm_unique_id_prefixes = set()
     for rest_device in coordinator.rest_devices:
         if isinstance(rest_device, RestPlus):
@@ -63,6 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                 ALARM_UNIQUE_ID_SUFFIX,
             )
             current_alarm_unique_ids.add(unique_id)
+            current_alarm_names[unique_id] = alarm_name
             entities.append(
                 HatchAlarmSwitch(
                     coordinator=coordinator,
@@ -80,6 +83,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         current_alarm_unique_ids=current_alarm_unique_ids,
         authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
         unique_id_suffix=ALARM_UNIQUE_ID_SUFFIX,
+    )
+    update_alarm_entity_names(
+        hass=hass,
+        config_entry=config_entry,
+        domain="switch",
+        current_alarm_names=current_alarm_names,
     )
     async_add_entities(entities)
 

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
+
 from homeassistant.components.switch import (
     SwitchEntity,
     SwitchDeviceClass, SwitchEntityDescription,
@@ -8,6 +10,7 @@ from homeassistant.components.switch import (
 from hatch_rest_api import RestPlus, RestIot, RestBaby
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HatchDataUpdateCoordinator
@@ -15,11 +18,16 @@ from .const import DOMAIN
 from .hatch_entity import HatchEntity
 
 _LOGGER = logging.getLogger(__name__)
+DEFAULT_ALARM_NAME = "alarm default name"
+ALARM_UNIQUE_ID_MARKER = "_alarm_"
+ALARM_UNIQUE_ID_SUFFIX = "_switch"
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
     entities = []
+    current_alarm_unique_ids = set()
+    authoritative_alarm_unique_id_prefixes = set()
     for rest_device in coordinator.rest_devices:
         if isinstance(rest_device, RestPlus):
             entities.append(HatchPowerSwitch(coordinator=coordinator, thing_name=rest_device.thing_name))
@@ -40,7 +48,29 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                     coordinator=coordinator, thing_name=rest_device.thing_name
                 )
             )
+        if getattr(rest_device, "alarms_loaded", False):
+            authoritative_alarm_unique_id_prefixes.add(
+                _alarm_unique_id_prefix(rest_device.thing_name)
+            )
+        for alarm_id, alarm_name in _alarm_switch_names(getattr(rest_device, "alarms", [])):
+            unique_id = _alarm_unique_id(rest_device.thing_name, alarm_id)
+            current_alarm_unique_ids.add(unique_id)
+            entities.append(
+                HatchAlarmSwitch(
+                    coordinator=coordinator,
+                    thing_name=rest_device.thing_name,
+                    alarm_id=alarm_id,
+                    alarm_name=alarm_name,
+                    unique_id=unique_id,
+                )
+            )
 
+    _remove_stale_alarm_switch_entities(
+        hass=hass,
+        config_entry=config_entry,
+        current_alarm_unique_ids=current_alarm_unique_ids,
+        authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+    )
     async_add_entities(entities)
 
 
@@ -83,3 +113,139 @@ class HatchToddlerLockSwitch(HatchEntity, SwitchEntity):
 
     def turn_off(self, **kwargs):
         self.rest_device.set_toddler_lock(False)
+
+
+class HatchAlarmSwitch(HatchEntity, SwitchEntity):
+    entity_description = SwitchEntityDescription(
+        key="alarm-switch",
+        icon="mdi:alarm",
+        device_class=SwitchDeviceClass.SWITCH,
+    )
+
+    def __init__(
+        self,
+        coordinator: HatchDataUpdateCoordinator,
+        thing_name: str,
+        alarm_id: int | str,
+        alarm_name: str,
+        unique_id: str,
+    ):
+        self._alarm_id = alarm_id
+        self._alarm_display_name = alarm_name
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Alarm",
+        )
+        self._attr_unique_id = unique_id
+        self._attr_has_entity_name = True
+        self._attr_name = alarm_name
+
+    @property
+    def available(self) -> bool:
+        return self._alarm is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        alarm = self._alarm
+        if alarm is None:
+            return None
+        return bool(alarm.get("enabled"))
+
+    async def async_turn_on(self, **kwargs):
+        await self._async_set_enabled(True)
+
+    async def async_turn_off(self, **kwargs):
+        await self._async_set_enabled(False)
+
+    async def _async_set_enabled(self, enabled: bool) -> None:
+        set_alarm_enabled = getattr(self.rest_device, "set_alarm_enabled", None)
+        if not callable(set_alarm_enabled):
+            raise TypeError(
+                f"{self.rest_device.device_name} does not support alarm switches"
+            )
+        await set_alarm_enabled(self._alarm_id, enabled)
+        self.async_write_ha_state()
+
+    @property
+    def _alarm(self) -> dict[str, Any] | None:
+        alarm_by_id = getattr(self.rest_device, "alarm_by_id", None)
+        if callable(alarm_by_id):
+            return alarm_by_id(self._alarm_id)
+        alarm_id_string = str(self._alarm_id)
+        return next(
+            (
+                alarm
+                for alarm in getattr(self.rest_device, "alarms", [])
+                if str(alarm.get("id")) == alarm_id_string
+            ),
+            None,
+        )
+
+
+def _alarm_switch_names(alarms: list[dict[str, Any]]):
+    default_alarm_count = 0
+    for alarm in alarms:
+        alarm_id = alarm.get("id")
+        if alarm_id is None:
+            continue
+
+        alarm_name = _clean_alarm_name(alarm.get("name"))
+        if _is_default_alarm_name(alarm_name):
+            default_alarm_count += 1
+            alarm_name = "Default" if default_alarm_count == 1 else str(default_alarm_count)
+
+        yield alarm_id, f"Alarm - {alarm_name}"
+
+
+def _clean_alarm_name(alarm_name: Any) -> str:
+    if alarm_name is None:
+        return ""
+    return " ".join(str(alarm_name).replace("_", " ").split())
+
+
+def _is_default_alarm_name(alarm_name: str) -> bool:
+    return alarm_name.lower() in {"", "default", DEFAULT_ALARM_NAME}
+
+
+def _alarm_unique_id(thing_name: str, alarm_id: int | str) -> str:
+    return f"{_alarm_unique_id_prefix(thing_name)}{alarm_id}{ALARM_UNIQUE_ID_SUFFIX}"
+
+
+def _alarm_unique_id_prefix(thing_name: str) -> str:
+    return f"{thing_name}{ALARM_UNIQUE_ID_MARKER}"
+
+
+def _remove_stale_alarm_switch_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    current_alarm_unique_ids: set[str],
+    authoritative_alarm_unique_id_prefixes: set[str],
+) -> None:
+    if not authoritative_alarm_unique_id_prefixes:
+        return
+
+    entity_registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(
+        entity_registry,
+        config_entry.entry_id,
+    ):
+        if entry.domain != "switch":
+            continue
+        if entry.unique_id in current_alarm_unique_ids:
+            continue
+        if _is_alarm_unique_id_for_authoritative_device(
+            entry.unique_id,
+            authoritative_alarm_unique_id_prefixes,
+        ):
+            entity_registry.async_remove(entry.entity_id)
+
+
+def _is_alarm_unique_id_for_authoritative_device(
+    unique_id: str,
+    authoritative_alarm_unique_id_prefixes: set[str],
+) -> bool:
+    return unique_id.endswith(ALARM_UNIQUE_ID_SUFFIX) and any(
+        unique_id.startswith(prefix)
+        for prefix in authoritative_alarm_unique_id_prefixes
+    )

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -31,9 +31,6 @@ ALARM_UNIQUE_ID_SUFFIX = "_switch"
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
     entities = []
-    current_alarm_unique_ids = set()
-    current_alarm_names = {}
-    authoritative_alarm_unique_id_prefixes = set()
     for rest_device in coordinator.rest_devices:
         if isinstance(rest_device, RestPlus):
             entities.append(HatchPowerSwitch(coordinator=coordinator, thing_name=rest_device.thing_name))
@@ -54,43 +51,70 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                     coordinator=coordinator, thing_name=rest_device.thing_name
                 )
             )
-        if getattr(rest_device, "alarms_loaded", False):
-            authoritative_alarm_unique_id_prefixes.add(
-                alarm_unique_id_prefix(rest_device.thing_name)
-            )
-        for alarm_id, alarm_name in alarm_base_names(getattr(rest_device, "alarms", [])):
-            unique_id = alarm_unique_id(
-                rest_device.thing_name,
-                alarm_id,
-                ALARM_UNIQUE_ID_SUFFIX,
-            )
-            current_alarm_unique_ids.add(unique_id)
-            current_alarm_names[unique_id] = alarm_name
-            entities.append(
-                HatchAlarmSwitch(
+
+    async_add_entities(entities)
+
+    alarm_entities_by_unique_id: dict[str, HatchAlarmSwitch] = {}
+
+    async def async_reconcile_alarm_entities() -> None:
+        new_alarm_entities = []
+        current_alarm_unique_ids = set()
+        current_alarm_names = {}
+        authoritative_alarm_unique_id_prefixes = set()
+        for rest_device in coordinator.rest_devices:
+            if getattr(rest_device, "alarms_loaded", False):
+                authoritative_alarm_unique_id_prefixes.add(
+                    alarm_unique_id_prefix(rest_device.thing_name)
+                )
+            for alarm_id, alarm_name in alarm_base_names(
+                getattr(rest_device, "alarms", [])
+            ):
+                unique_id = alarm_unique_id(
+                    rest_device.thing_name,
+                    alarm_id,
+                    ALARM_UNIQUE_ID_SUFFIX,
+                )
+                current_alarm_unique_ids.add(unique_id)
+                current_alarm_names[unique_id] = alarm_name
+                if alarm_entity := alarm_entities_by_unique_id.get(unique_id):
+                    alarm_entity.update_alarm_name(alarm_name)
+                    continue
+
+                alarm_entity = HatchAlarmSwitch(
                     coordinator=coordinator,
                     thing_name=rest_device.thing_name,
                     alarm_id=alarm_id,
                     alarm_name=alarm_name,
                     unique_id=unique_id,
                 )
-            )
+                alarm_entities_by_unique_id[unique_id] = alarm_entity
+                new_alarm_entities.append(alarm_entity)
 
-    remove_stale_alarm_entities(
-        hass=hass,
-        config_entry=config_entry,
-        domain="switch",
-        current_alarm_unique_ids=current_alarm_unique_ids,
-        authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
-        unique_id_suffix=ALARM_UNIQUE_ID_SUFFIX,
+        for unique_id in set(alarm_entities_by_unique_id) - current_alarm_unique_ids:
+            alarm_entity = alarm_entities_by_unique_id.pop(unique_id)
+            await alarm_entity.async_remove(force_remove=True)
+
+        remove_stale_alarm_entities(
+            hass=hass,
+            config_entry=config_entry,
+            domain="switch",
+            current_alarm_unique_ids=current_alarm_unique_ids,
+            authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+            unique_id_suffix=ALARM_UNIQUE_ID_SUFFIX,
+        )
+        update_alarm_entity_names(
+            hass=hass,
+            config_entry=config_entry,
+            domain="switch",
+            current_alarm_names=current_alarm_names,
+        )
+        if new_alarm_entities:
+            async_add_entities(new_alarm_entities)
+
+    await async_reconcile_alarm_entities()
+    config_entry.async_on_unload(
+        coordinator.async_add_alarm_refresh_callback(async_reconcile_alarm_entities)
     )
-    update_alarm_entity_names(
-        hass=hass,
-        config_entry=config_entry,
-        domain="switch",
-        current_alarm_names=current_alarm_names,
-    )
-    async_add_entities(entities)
 
 
 class HatchPowerSwitch(HatchEntity, SwitchEntity):
@@ -159,6 +183,13 @@ class HatchAlarmSwitch(HatchEntity, SwitchEntity):
         self._attr_unique_id = unique_id
         self._attr_has_entity_name = True
         self._attr_name = alarm_name
+
+    def update_alarm_name(self, alarm_name: str) -> None:
+        if self._attr_name == alarm_name:
+            return
+        self._attr_name = alarm_name
+        if getattr(self, "hass", None) is not None:
+            self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -190,7 +190,7 @@ class HatchAlarmSwitch(HatchEntity, SwitchEntity):
             return
         self._attr_name = alarm_name
         if getattr(self, "hass", None) is not None:
-            self.async_write_ha_state()
+            self.schedule_update_ha_state()
 
     @property
     def available(self) -> bool:
@@ -220,7 +220,7 @@ class HatchAlarmSwitch(HatchEntity, SwitchEntity):
                 f"{self.rest_device.device_name} does not support alarm switches"
             )
         await set_alarm_enabled(self._alarm_id, enabled)
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
 
     @property
     def _alarm(self) -> dict[str, Any] | None:

--- a/custom_components/ha_hatch/switch.py
+++ b/custom_components/ha_hatch/switch.py
@@ -10,16 +10,20 @@ from homeassistant.components.switch import (
 from hatch_rest_api import RestPlus, RestIot, RestBaby
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HatchDataUpdateCoordinator
+from .alarm import (
+    alarm_base_names,
+    alarm_by_id,
+    alarm_unique_id,
+    alarm_unique_id_prefix,
+    remove_stale_alarm_entities,
+)
 from .const import DOMAIN
 from .hatch_entity import HatchEntity
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_ALARM_NAME = "alarm default name"
-ALARM_UNIQUE_ID_MARKER = "_alarm_"
 ALARM_UNIQUE_ID_SUFFIX = "_switch"
 
 
@@ -50,10 +54,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             )
         if getattr(rest_device, "alarms_loaded", False):
             authoritative_alarm_unique_id_prefixes.add(
-                _alarm_unique_id_prefix(rest_device.thing_name)
+                alarm_unique_id_prefix(rest_device.thing_name)
             )
-        for alarm_id, alarm_name in _alarm_switch_names(getattr(rest_device, "alarms", [])):
-            unique_id = _alarm_unique_id(rest_device.thing_name, alarm_id)
+        for alarm_id, alarm_name in alarm_base_names(getattr(rest_device, "alarms", [])):
+            unique_id = alarm_unique_id(
+                rest_device.thing_name,
+                alarm_id,
+                ALARM_UNIQUE_ID_SUFFIX,
+            )
             current_alarm_unique_ids.add(unique_id)
             entities.append(
                 HatchAlarmSwitch(
@@ -65,11 +73,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                 )
             )
 
-    _remove_stale_alarm_switch_entities(
+    remove_stale_alarm_entities(
         hass=hass,
         config_entry=config_entry,
+        domain="switch",
         current_alarm_unique_ids=current_alarm_unique_ids,
         authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+        unique_id_suffix=ALARM_UNIQUE_ID_SUFFIX,
     )
     async_add_entities(entities)
 
@@ -169,83 +179,4 @@ class HatchAlarmSwitch(HatchEntity, SwitchEntity):
 
     @property
     def _alarm(self) -> dict[str, Any] | None:
-        alarm_by_id = getattr(self.rest_device, "alarm_by_id", None)
-        if callable(alarm_by_id):
-            return alarm_by_id(self._alarm_id)
-        alarm_id_string = str(self._alarm_id)
-        return next(
-            (
-                alarm
-                for alarm in getattr(self.rest_device, "alarms", [])
-                if str(alarm.get("id")) == alarm_id_string
-            ),
-            None,
-        )
-
-
-def _alarm_switch_names(alarms: list[dict[str, Any]]):
-    default_alarm_count = 0
-    for alarm in alarms:
-        alarm_id = alarm.get("id")
-        if alarm_id is None:
-            continue
-
-        alarm_name = _clean_alarm_name(alarm.get("name"))
-        if _is_default_alarm_name(alarm_name):
-            default_alarm_count += 1
-            alarm_name = "Default" if default_alarm_count == 1 else str(default_alarm_count)
-
-        yield alarm_id, f"Alarm - {alarm_name}"
-
-
-def _clean_alarm_name(alarm_name: Any) -> str:
-    if alarm_name is None:
-        return ""
-    return " ".join(str(alarm_name).replace("_", " ").split())
-
-
-def _is_default_alarm_name(alarm_name: str) -> bool:
-    return alarm_name.lower() in {"", "default", DEFAULT_ALARM_NAME}
-
-
-def _alarm_unique_id(thing_name: str, alarm_id: int | str) -> str:
-    return f"{_alarm_unique_id_prefix(thing_name)}{alarm_id}{ALARM_UNIQUE_ID_SUFFIX}"
-
-
-def _alarm_unique_id_prefix(thing_name: str) -> str:
-    return f"{thing_name}{ALARM_UNIQUE_ID_MARKER}"
-
-
-def _remove_stale_alarm_switch_entities(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    current_alarm_unique_ids: set[str],
-    authoritative_alarm_unique_id_prefixes: set[str],
-) -> None:
-    if not authoritative_alarm_unique_id_prefixes:
-        return
-
-    entity_registry = er.async_get(hass)
-    for entry in er.async_entries_for_config_entry(
-        entity_registry,
-        config_entry.entry_id,
-    ):
-        if entry.domain != "switch":
-            continue
-        if entry.unique_id in current_alarm_unique_ids:
-            continue
-        if _is_alarm_unique_id_for_authoritative_device(
-            entry.unique_id,
-            authoritative_alarm_unique_id_prefixes,
-        ):
-            entity_registry.async_remove(entry.entity_id)
-
-
-def _is_alarm_unique_id_for_authoritative_device(
-    unique_id: str,
-    authoritative_alarm_unique_id_prefixes: set[str],
-) -> bool:
-    return unique_id.endswith(ALARM_UNIQUE_ID_SUFFIX) and any(
-        unique_id.startswith(prefix)
-        for prefix in authoritative_alarm_unique_id_prefixes
-    )
+        return alarm_by_id(self.rest_device, self._alarm_id)

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -32,49 +32,68 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ):
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
-    entities = []
-    current_alarm_unique_ids = set()
-    current_alarm_names = {}
-    authoritative_alarm_unique_id_prefixes = set()
-    for rest_device in coordinator.rest_devices:
-        if getattr(rest_device, "alarms_loaded", False):
-            authoritative_alarm_unique_id_prefixes.add(
-                alarm_unique_id_prefix(rest_device.thing_name)
-            )
-        for alarm_id, alarm_name in alarm_base_names(getattr(rest_device, "alarms", [])):
-            unique_id = alarm_unique_id(
-                rest_device.thing_name,
-                alarm_id,
-                ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
-            )
-            wake_time_name = f"{alarm_name} Wake Time"
-            current_alarm_unique_ids.add(unique_id)
-            current_alarm_names[unique_id] = wake_time_name
-            entities.append(
-                HatchAlarmWakeTime(
+    alarm_entities_by_unique_id: dict[str, HatchAlarmWakeTime] = {}
+
+    async def async_reconcile_alarm_entities() -> None:
+        new_alarm_entities = []
+        current_alarm_unique_ids = set()
+        current_alarm_names = {}
+        authoritative_alarm_unique_id_prefixes = set()
+        for rest_device in coordinator.rest_devices:
+            if getattr(rest_device, "alarms_loaded", False):
+                authoritative_alarm_unique_id_prefixes.add(
+                    alarm_unique_id_prefix(rest_device.thing_name)
+                )
+            for alarm_id, alarm_name in alarm_base_names(
+                getattr(rest_device, "alarms", [])
+            ):
+                unique_id = alarm_unique_id(
+                    rest_device.thing_name,
+                    alarm_id,
+                    ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+                )
+                wake_time_name = f"{alarm_name} Wake Time"
+                current_alarm_unique_ids.add(unique_id)
+                current_alarm_names[unique_id] = wake_time_name
+                if alarm_entity := alarm_entities_by_unique_id.get(unique_id):
+                    alarm_entity.update_alarm_name(wake_time_name)
+                    continue
+
+                alarm_entity = HatchAlarmWakeTime(
                     coordinator=coordinator,
                     thing_name=rest_device.thing_name,
                     alarm_id=alarm_id,
                     alarm_name=wake_time_name,
                     unique_id=unique_id,
                 )
-            )
+                alarm_entities_by_unique_id[unique_id] = alarm_entity
+                new_alarm_entities.append(alarm_entity)
 
-    remove_stale_alarm_entities(
-        hass=hass,
-        config_entry=config_entry,
-        domain="time",
-        current_alarm_unique_ids=current_alarm_unique_ids,
-        authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
-        unique_id_suffix=ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+        for unique_id in set(alarm_entities_by_unique_id) - current_alarm_unique_ids:
+            alarm_entity = alarm_entities_by_unique_id.pop(unique_id)
+            await alarm_entity.async_remove(force_remove=True)
+
+        remove_stale_alarm_entities(
+            hass=hass,
+            config_entry=config_entry,
+            domain="time",
+            current_alarm_unique_ids=current_alarm_unique_ids,
+            authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+            unique_id_suffix=ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+        )
+        update_alarm_entity_names(
+            hass=hass,
+            config_entry=config_entry,
+            domain="time",
+            current_alarm_names=current_alarm_names,
+        )
+        if new_alarm_entities:
+            async_add_entities(new_alarm_entities)
+
+    await async_reconcile_alarm_entities()
+    config_entry.async_on_unload(
+        coordinator.async_add_alarm_refresh_callback(async_reconcile_alarm_entities)
     )
-    update_alarm_entity_names(
-        hass=hass,
-        config_entry=config_entry,
-        domain="time",
-        current_alarm_names=current_alarm_names,
-    )
-    async_add_entities(entities)
 
 
 class HatchAlarmWakeTime(HatchEntity, TimeEntity):
@@ -100,6 +119,13 @@ class HatchAlarmWakeTime(HatchEntity, TimeEntity):
         self._attr_unique_id = unique_id
         self._attr_has_entity_name = True
         self._attr_name = alarm_name
+
+    def update_alarm_name(self, alarm_name: str) -> None:
+        if self._attr_name == alarm_name:
+            return
+        self._attr_name = alarm_name
+        if getattr(self, "hass", None) is not None:
+            self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -130,7 +130,7 @@ class HatchAlarmWakeTime(HatchEntity, TimeEntity):
 
     @property
     def available(self) -> bool:
-        return self.native_value is not None
+        return self._alarm is not None
 
     @property
     def native_value(self) -> time | None:

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -13,6 +13,7 @@ from . import HatchDataUpdateCoordinator
 from .alarm import (
     alarm_base_names,
     alarm_by_id,
+    alarm_repeat_attributes,
     alarm_unique_id,
     alarm_unique_id_prefix,
     alarm_wake_time,
@@ -134,6 +135,10 @@ class HatchAlarmWakeTime(HatchEntity, TimeEntity):
     @property
     def native_value(self) -> time | None:
         return alarm_wake_time(self._alarm)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return alarm_repeat_attributes(self._alarm)
 
     async def async_set_value(self, value: time) -> None:
         set_alarm_wake_time = getattr(self.rest_device, "set_alarm_wake_time", None)

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -126,7 +126,7 @@ class HatchAlarmWakeTime(HatchEntity, TimeEntity):
             return
         self._attr_name = alarm_name
         if getattr(self, "hass", None) is not None:
-            self.async_write_ha_state()
+            self.schedule_update_ha_state()
 
     @property
     def available(self) -> bool:
@@ -147,7 +147,7 @@ class HatchAlarmWakeTime(HatchEntity, TimeEntity):
                 f"{self.rest_device.device_name} does not support alarm wake times"
             )
         await set_alarm_wake_time(self._alarm_id, value)
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
 
     @property
     def _alarm(self) -> dict[str, Any] | None:

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+from datetime import time
+from typing import Any
+
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HatchDataUpdateCoordinator
+from .alarm import (
+    alarm_base_names,
+    alarm_by_id,
+    alarm_unique_id,
+    alarm_unique_id_prefix,
+    alarm_wake_time,
+    remove_stale_alarm_entities,
+)
+from .const import DOMAIN
+from .hatch_entity import HatchEntity
+
+_LOGGER = logging.getLogger(__name__)
+ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX = "_wake_time"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
+    entities = []
+    current_alarm_unique_ids = set()
+    authoritative_alarm_unique_id_prefixes = set()
+    for rest_device in coordinator.rest_devices:
+        if getattr(rest_device, "alarms_loaded", False):
+            authoritative_alarm_unique_id_prefixes.add(
+                alarm_unique_id_prefix(rest_device.thing_name)
+            )
+        for alarm_id, alarm_name in alarm_base_names(getattr(rest_device, "alarms", [])):
+            unique_id = alarm_unique_id(
+                rest_device.thing_name,
+                alarm_id,
+                ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+            )
+            current_alarm_unique_ids.add(unique_id)
+            entities.append(
+                HatchAlarmWakeTime(
+                    coordinator=coordinator,
+                    thing_name=rest_device.thing_name,
+                    alarm_id=alarm_id,
+                    alarm_name=f"{alarm_name} Wake Time",
+                    unique_id=unique_id,
+                )
+            )
+
+    remove_stale_alarm_entities(
+        hass=hass,
+        config_entry=config_entry,
+        domain="time",
+        current_alarm_unique_ids=current_alarm_unique_ids,
+        authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
+        unique_id_suffix=ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+    )
+    async_add_entities(entities)
+
+
+class HatchAlarmWakeTime(HatchEntity, TimeEntity):
+    entity_description = TimeEntityDescription(
+        key="alarm-wake-time",
+        icon="mdi:alarm",
+    )
+
+    def __init__(
+        self,
+        coordinator: HatchDataUpdateCoordinator,
+        thing_name: str,
+        alarm_id: int | str,
+        alarm_name: str,
+        unique_id: str,
+    ):
+        self._alarm_id = alarm_id
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Alarm",
+        )
+        self._attr_unique_id = unique_id
+        self._attr_has_entity_name = True
+        self._attr_name = alarm_name
+
+    @property
+    def available(self) -> bool:
+        return self.native_value is not None
+
+    @property
+    def native_value(self) -> time | None:
+        return alarm_wake_time(self._alarm)
+
+    async def async_set_value(self, value: time) -> None:
+        set_alarm_wake_time = getattr(self.rest_device, "set_alarm_wake_time", None)
+        if not callable(set_alarm_wake_time):
+            raise TypeError(
+                f"{self.rest_device.device_name} does not support alarm wake times"
+            )
+        await set_alarm_wake_time(self._alarm_id, value)
+        self.async_write_ha_state()
+
+    @property
+    def _alarm(self) -> dict[str, Any] | None:
+        return alarm_by_id(self.rest_device, self._alarm_id)

--- a/custom_components/ha_hatch/time.py
+++ b/custom_components/ha_hatch/time.py
@@ -17,6 +17,7 @@ from .alarm import (
     alarm_unique_id_prefix,
     alarm_wake_time,
     remove_stale_alarm_entities,
+    update_alarm_entity_names,
 )
 from .const import DOMAIN
 from .hatch_entity import HatchEntity
@@ -33,6 +34,7 @@ async def async_setup_entry(
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
     entities = []
     current_alarm_unique_ids = set()
+    current_alarm_names = {}
     authoritative_alarm_unique_id_prefixes = set()
     for rest_device in coordinator.rest_devices:
         if getattr(rest_device, "alarms_loaded", False):
@@ -45,13 +47,15 @@ async def async_setup_entry(
                 alarm_id,
                 ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
             )
+            wake_time_name = f"{alarm_name} Wake Time"
             current_alarm_unique_ids.add(unique_id)
+            current_alarm_names[unique_id] = wake_time_name
             entities.append(
                 HatchAlarmWakeTime(
                     coordinator=coordinator,
                     thing_name=rest_device.thing_name,
                     alarm_id=alarm_id,
-                    alarm_name=f"{alarm_name} Wake Time",
+                    alarm_name=wake_time_name,
                     unique_id=unique_id,
                 )
             )
@@ -63,6 +67,12 @@ async def async_setup_entry(
         current_alarm_unique_ids=current_alarm_unique_ids,
         authoritative_alarm_unique_id_prefixes=authoritative_alarm_unique_id_prefixes,
         unique_id_suffix=ALARM_WAKE_TIME_UNIQUE_ID_SUFFIX,
+    )
+    update_alarm_entity_names(
+        hass=hass,
+        config_entry=config_entry,
+        domain="time",
+        current_alarm_names=current_alarm_names,
     )
     async_add_entities(entities)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant==2025.1.0
 ruff==0.15.12
-hatch-rest-api==1.32.1
+hatch-rest-api==1.33.0

--- a/tests/test_alarm_helpers.py
+++ b/tests/test_alarm_helpers.py
@@ -99,6 +99,18 @@ class AlarmHelperTest(unittest.TestCase):
             },
         )
         self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 127})["weekdays"],
+            [
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+                "sunday",
+            ],
+        )
+        self.assertEqual(
             alarm_helpers.alarm_repeat_attributes({"daysOfWeek": "bad"}),
             {
                 "repeat": "Unknown",

--- a/tests/test_alarm_helpers.py
+++ b/tests/test_alarm_helpers.py
@@ -25,7 +25,7 @@ class AlarmHelperTest(unittest.TestCase):
         self.assertEqual(
             list(alarm_helpers.alarm_base_names(alarms)),
             [
-                (1, "Alarm - Default"),
+                (1, "Default Alarm"),
                 (2, "Alarm - 2"),
                 (3, "Alarm - Weekend Wake"),
             ],

--- a/tests/test_alarm_helpers.py
+++ b/tests/test_alarm_helpers.py
@@ -27,7 +27,7 @@ class AlarmHelperTest(unittest.TestCase):
             [
                 (1, "Default Alarm"),
                 (2, "Alarm - 2"),
-                (3, "Alarm - Weekend Wake"),
+                (3, "Weekend Wake Alarm"),
             ],
         )
 

--- a/tests/test_alarm_helpers.py
+++ b/tests/test_alarm_helpers.py
@@ -37,6 +37,87 @@ class AlarmHelperTest(unittest.TestCase):
             "thing-name_alarm_42_wake_time",
         )
 
+    def test_alarm_reference_from_unique_id_accepts_alarm_entity_suffixes(self):
+        self.assertEqual(
+            alarm_helpers.alarm_reference_from_unique_id(
+                "thing-name_alarm_42_wake_time",
+                {"_switch", "_wake_time"},
+            ),
+            ("thing-name", "42"),
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_reference_from_unique_id(
+                "thing-name_alarm_42_switch",
+                {"_switch", "_wake_time"},
+            ),
+            ("thing-name", "42"),
+        )
+        self.assertIsNone(
+            alarm_helpers.alarm_reference_from_unique_id(
+                "thing-name_power_switch",
+                {"_switch", "_wake_time"},
+            )
+        )
+
+    def test_alarm_repeat_attributes_describe_days_of_week(self):
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 62}),
+            {
+                "repeat": "Weekdays",
+                "weekdays": [
+                    "monday",
+                    "tuesday",
+                    "wednesday",
+                    "thursday",
+                    "friday",
+                ],
+                "days_of_week": 62,
+            },
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 65})["repeat"],
+            "Weekends",
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 127})["repeat"],
+            "Every day",
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 42}),
+            {
+                "repeat": "Mon, Wed, Fri",
+                "weekdays": ["monday", "wednesday", "friday"],
+                "days_of_week": 42,
+            },
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": 0}),
+            {
+                "repeat": "Once",
+                "weekdays": [],
+                "days_of_week": 0,
+            },
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_repeat_attributes({"daysOfWeek": "bad"}),
+            {
+                "repeat": "Unknown",
+                "weekdays": [],
+                "days_of_week": "bad",
+            },
+        )
+
+    def test_normalize_alarm_weekdays_accepts_ui_values(self):
+        self.assertEqual(
+            alarm_helpers.normalize_alarm_weekdays([" Monday ", "FRIDAY"]),
+            ["monday", "friday"],
+        )
+        self.assertEqual(alarm_helpers.normalize_alarm_weekdays([]), [])
+        with self.assertRaisesRegex(ValueError, "Unsupported alarm weekday"):
+            alarm_helpers.normalize_alarm_weekdays(["funday"])
+        with self.assertRaisesRegex(ValueError, "must be a list"):
+            alarm_helpers.normalize_alarm_weekdays(62)
+
     def test_alarm_wake_time_reads_end_time_and_derives_missing_end_time(self):
         self.assertEqual(
             alarm_helpers.alarm_wake_time(

--- a/tests/test_alarm_helpers.py
+++ b/tests/test_alarm_helpers.py
@@ -1,0 +1,93 @@
+from datetime import time
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import unittest
+
+ALARM_MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "ha_hatch"
+    / "alarm.py"
+)
+SPEC = spec_from_file_location("ha_hatch_alarm_helpers", ALARM_MODULE_PATH)
+alarm_helpers = module_from_spec(SPEC)
+SPEC.loader.exec_module(alarm_helpers)
+
+
+class AlarmHelperTest(unittest.TestCase):
+    def test_alarm_base_names_handles_default_and_named_alarms(self):
+        alarms = [
+            {"id": 1, "name": "Alarm_Default_Name"},
+            {"id": 2, "name": ""},
+            {"id": 3, "name": "Weekend_Wake"},
+        ]
+
+        self.assertEqual(
+            list(alarm_helpers.alarm_base_names(alarms)),
+            [
+                (1, "Alarm - Default"),
+                (2, "Alarm - 2"),
+                (3, "Alarm - Weekend Wake"),
+            ],
+        )
+
+    def test_alarm_unique_id_uses_device_alarm_and_suffix(self):
+        self.assertEqual(
+            alarm_helpers.alarm_unique_id("thing-name", 42, "_wake_time"),
+            "thing-name_alarm_42_wake_time",
+        )
+
+    def test_alarm_wake_time_reads_end_time_and_derives_missing_end_time(self):
+        self.assertEqual(
+            alarm_helpers.alarm_wake_time(
+                {
+                    "startTime": "2026-05-08T07:30:00",
+                    "endTime": "2026-05-08T08:00:00",
+                }
+            ),
+            time(8, 0),
+        )
+        self.assertEqual(
+            alarm_helpers.alarm_wake_time(
+                {
+                    "startTime": "2026-05-08T10:45:00",
+                    "endTime": None,
+                    "steps": [
+                        {
+                            "name": "Sunrise",
+                            "enabled": True,
+                            "color": {"duration": 2700, "ignore": False},
+                        }
+                    ],
+                }
+            ),
+            time(11, 30),
+        )
+        self.assertIsNone(
+            alarm_helpers.alarm_wake_time(
+                {
+                    "startTime": "2026-05-08T10:45:00",
+                    "endTime": None,
+                }
+            )
+        )
+        self.assertIsNone(
+            alarm_helpers.alarm_wake_time(
+                {
+                    "startTime": None,
+                    "endTime": "2026-05-08T08:00:00",
+                }
+            )
+        )
+        self.assertIsNone(
+            alarm_helpers.alarm_wake_time(
+                {
+                    "startTime": "2026-05-08T07:30:00",
+                    "endTime": "not-a-date",
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I've added alarm support! This solves #260. Each wake-up alarm is synced with the app, and can be enabled/disabled with the switch. The wake-up time can also be selected with a time entity. As I didn't find a good way to select which weekday the alarms are activated with entities, I made a service.

I also purposefully didn't add alarm adding support, as that would require adding sound selection support, which is very complicated to do in HA compared to in-app.

Requires: https://github.com/dahlb/hatch_rest_api/pull/53