### PR TITLE
feat: Restore 3 routine controls (advance, swap, pause, snooze, stop)

### DIFF
--- a/custom_components/ha_hatch/button.py
+++ b/custom_components/ha_hatch/button.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from hatch_rest_api import RestoreV5
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HatchDataUpdateCoordinator
+from .const import DOMAIN
+from .hatch_entity import HatchEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
+    entities: list[ButtonEntity] = []
+    for rest_device in coordinator.rest_devices:
+        if isinstance(rest_device, RestoreV5):
+            entities.append(
+                HatchStopRoutineButton(
+                    coordinator=coordinator, thing_name=rest_device.thing_name
+                )
+            )
+            entities.append(
+                HatchSnoozeAlarmButton(
+                    coordinator=coordinator, thing_name=rest_device.thing_name
+                )
+            )
+            entities.append(
+                HatchAdvanceStepButton(
+                    coordinator=coordinator, thing_name=rest_device.thing_name
+                )
+            )
+            entities.append(
+                HatchSwapRoutineButton(
+                    coordinator=coordinator, thing_name=rest_device.thing_name
+                )
+            )
+    async_add_entities(entities)
+
+
+class HatchStopRoutineButton(HatchEntity, ButtonEntity):
+    entity_description = ButtonEntityDescription(
+        key="stop_routine",
+        icon="mdi:stop",
+    )
+
+    def __init__(
+        self, coordinator: HatchDataUpdateCoordinator, thing_name: str
+    ):
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Stop Routine",
+        )
+
+    @property
+    def available(self) -> bool:
+        device = self.rest_device
+        return device is not None and device.current_playing != "none"
+
+    def press(self) -> None:
+        self.rest_device.stop_routine()
+
+
+class HatchSnoozeAlarmButton(HatchEntity, ButtonEntity):
+    entity_description = ButtonEntityDescription(
+        key="snooze_alarm",
+        icon="mdi:alarm-snooze",
+    )
+
+    def __init__(
+        self, coordinator: HatchDataUpdateCoordinator, thing_name: str
+    ):
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Snooze Alarm",
+        )
+
+    @property
+    def available(self) -> bool:
+        device = self.rest_device
+        if device is None:
+            return False
+        return device.current_playing == "routine" and not device.is_snoozed
+
+    def press(self) -> None:
+        self.rest_device.snooze_alarm()
+
+
+class HatchAdvanceStepButton(HatchEntity, ButtonEntity):
+    entity_description = ButtonEntityDescription(
+        key="advance_step",
+        icon="mdi:skip-next",
+    )
+
+    def __init__(
+        self, coordinator: HatchDataUpdateCoordinator, thing_name: str
+    ):
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Advance Step",
+        )
+
+    @property
+    def available(self) -> bool:
+        device = self.rest_device
+        return device is not None and device.can_advance_step
+
+    def press(self) -> None:
+        self.rest_device.advance_step()
+
+
+class HatchSwapRoutineButton(HatchEntity, ButtonEntity):
+    entity_description = ButtonEntityDescription(
+        key="swap_routine",
+        icon="mdi:swap-horizontal",
+    )
+
+    def __init__(
+        self, coordinator: HatchDataUpdateCoordinator, thing_name: str
+    ):
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type="Swap Routine",
+        )
+
+    @property
+    def available(self) -> bool:
+        device = self.rest_device
+        return device is not None and device.can_swap_routine
+
+    async def async_press(self) -> None:
+        await self.rest_device.swap_routine()
+        self.schedule_update_ha_state()

--- a/custom_components/ha_hatch/const.py
+++ b/custom_components/ha_hatch/const.py
@@ -11,6 +11,7 @@ CONFIG_TURN_ON_DEFAULT: bool = True
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.LIGHT,
     Platform.MEDIA_PLAYER,
     Platform.SCENE,

--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
   "loggers": ["ha_hatch", "hatch_rest_api"],
-  "requirements": ["hatch_rest_api==1.33.0"],
+  "requirements": ["hatch_rest_api==1.34.0"],
   "version": "1.29.0"
 }

--- a/custom_components/ha_hatch/media_riot_entity.py
+++ b/custom_components/ha_hatch/media_riot_entity.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import (
     STATE_IDLE,
+    STATE_PAUSED,
     STATE_PLAYING,
 )
 
@@ -24,6 +25,7 @@ from hatch_rest_api import (
     RestBabyAudioTrack,
     REST_BABY_AUDIO_TRACKS,
     RestBaby,
+    RestoreV5,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,7 +64,7 @@ class MediaRiotEntity(HatchEntity, MediaPlayerEntity):
                 + list(self.rest_device.sounds_by_name.keys())
             )
         )
-        self._attr_supported_features = (
+        features = (
             MediaPlayerEntityFeature.PLAY
             | MediaPlayerEntityFeature.STOP
             | MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -70,10 +72,15 @@ class MediaRiotEntity(HatchEntity, MediaPlayerEntity):
             | MediaPlayerEntityFeature.VOLUME_STEP
             | MediaPlayerEntityFeature.SELECT_SOURCE
         )
+        if isinstance(self.rest_device, RestoreV5):
+            features |= MediaPlayerEntityFeature.PAUSE
+        self._attr_supported_features = features
         self._attr_extra_state_attributes = {}
 
     @property
     def state(self) -> MediaPlayerState | None:
+        if isinstance(self.rest_device, RestoreV5) and self.rest_device.paused:
+            return STATE_PAUSED
         if self.rest_device.is_playing:
             return STATE_PLAYING
         else:
@@ -113,12 +120,20 @@ class MediaRiotEntity(HatchEntity, MediaPlayerEntity):
 
     def media_play(self) -> None:
         _LOGGER.debug("media play")
+        if isinstance(self.rest_device, RestoreV5) and self.rest_device.paused:
+            self.rest_device.resume_routine()
+            return
         if self.rest_device.is_playing:
             _LOGGER.debug("media player already playing")
             return
         new_sound_mode = self.sound_mode or self._attr_sound_mode_list[0]
         _LOGGER.debug("selecting sound mode of %s", new_sound_mode)
         self.select_sound_mode(new_sound_mode)
+
+    def media_pause(self) -> None:
+        _LOGGER.debug("media pause")
+        if isinstance(self.rest_device, RestoreV5):
+            self.rest_device.pause_routine()
 
     def select_sound_mode(self, sound_mode: str) -> None:
         _LOGGER.debug("Select sound mode: %s", sound_mode)

--- a/custom_components/ha_hatch/sensor.py
+++ b/custom_components/ha_hatch/sensor.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
-from hatch_rest_api import RestPlus, RestIot
+from homeassistant.const import EntityCategory, PERCENTAGE
+from hatch_rest_api import RestPlus, RestIot, RestoreV5
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -42,6 +42,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             sensor_entities.append(HatchBattery(coordinator=coordinator, thing_name=rest_device.thing_name))
         if isinstance(rest_device, RestIot):
             sensor_entities.append(HatchCharging(coordinator=coordinator, thing_name=rest_device.thing_name))
+        if isinstance(rest_device, RestoreV5):
+            sensor_entities.append(HatchRoutine(coordinator=coordinator, thing_name=rest_device.thing_name))
+            sensor_entities.append(HatchRoutineStep(coordinator=coordinator, thing_name=rest_device.thing_name))
+            sensor_entities.append(HatchPlaybackState(coordinator=coordinator, thing_name=rest_device.thing_name))
     async_add_entities(sensor_entities)
 
     alarm_entities_by_unique_id: dict[str, HatchAlarmRepeat] = {}
@@ -199,3 +203,66 @@ class HatchAlarmRepeat(HatchEntity, SensorEntity):
     @property
     def _alarm(self) -> dict[str, Any] | None:
         return alarm_by_id(self.rest_device, self._alarm_id)
+
+
+class HatchRoutine(HatchEntity, SensorEntity):
+    entity_description = SensorEntityDescription(
+        key="routine",
+        icon="mdi:playlist-music",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    def __init__(self, coordinator: HatchDataUpdateCoordinator, thing_name: str):
+        super().__init__(coordinator=coordinator, thing_name=thing_name, entity_type="Routine")
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        device = self.rest_device
+        if device is None or not device.current_id:
+            return None
+        favorite = next(
+            (f for f in device.favorites if f.get("id") == device.current_id),
+            None,
+        )
+        if favorite is None:
+            return str(device.current_id)
+        steps = favorite.get("steps") or []
+        if steps and steps[0].get("name"):
+            return steps[0]["name"]
+        return favorite.get("name") or str(device.current_id)
+
+
+class HatchRoutineStep(HatchEntity, SensorEntity):
+    entity_description = SensorEntityDescription(
+        key="routine_step",
+        icon="mdi:counter",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    def __init__(self, coordinator: HatchDataUpdateCoordinator, thing_name: str):
+        super().__init__(coordinator=coordinator, thing_name=thing_name, entity_type="Routine Step")
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        device = self.rest_device
+        if device is None:
+            return None
+        return device.current_step
+
+
+class HatchPlaybackState(HatchEntity, SensorEntity):
+    entity_description = SensorEntityDescription(
+        key="playback_state",
+        icon="mdi:play-circle-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    def __init__(self, coordinator: HatchDataUpdateCoordinator, thing_name: str):
+        super().__init__(coordinator=coordinator, thing_name=thing_name, entity_type="Playback State")
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        device = self.rest_device
+        if device is None:
+            return None
+        return device.current_playing


### PR DESCRIPTION
## Summary

Surfaces what the Restore 3's three on-device buttons do to Home Assistant, so HA automations can drive (and be driven by) the same gestures the physical buttons do — e.g. an HA wall remote that snoozes the morning alarm, or a \"swap to white-noise routine\" automation tied to the baby monitor.

- **New `button` platform** (`Platform.BUTTON` added to PLATFORMS):
  - `button.<device>_stop_routine` — stops any playing routine. Available when something is playing.
  - `button.<device>_snooze_alarm` — snoozes the active alarm. Available when an alarm-routine is sounding and not already snoozed.
  - `button.<device>_advance_step` — advances to the next step within the playing routine. Available when a routine is playing AND not at its last step.
  - `button.<device>_swap_routine` — async; cycles to the next configured swappable Unwind. Available when ≥ 2 swappable routines exist.
- **Media player pause/resume on Restore V5**: adds `MediaPlayerEntityFeature.PAUSE`, returns `STATE_PAUSED` when `current.paused` is true, wires `media_pause` → `pause_routine` and `media_play` → `resume_routine` when currently paused.
- **Three diagnostic sensors** on Restore V5 to make the new actions observable:
  - `sensor.<device>_routine` — current step name (or favorite name as a fallback).
  - `sensor.<device>_routine_step` — current step index.
  - `sensor.<device>_playback_state` — raw `none` / `remote` / `routine` / `paused`.

Depends on `hatch_rest_api` 1.34.0 (PR https://github.com/dahlb/hatch_rest_api/pull/54). Pin bumped accordingly.

## Test plan

- [ ] Restart HA, verify the new button + sensor entities appear on the Restore 3 device card.
- [ ] Start an Unwind via existing scene → press `button.<device>_advance_step` → device skips to next step; `sensor.routine_step` increments.
- [ ] Press `button.<device>_stop_routine` → device silences.
- [ ] During a routine, call `media_player.media_pause` → audio pauses; `sensor.playback_state` reads `paused`. Call `media_player.media_play` → resumes.
- [ ] Configure 2-3 Unwind swappable routines in the Hatch app; press `button.<device>_swap_routine` → next configured Unwind plays.
- [ ] Schedule an alarm a minute out; when it fires press `button.<device>_snooze_alarm` → device silences and re-fires after the configured snooze duration.