### PR TITLE
Add optional preset numbers to Hatch favorite scenes

### DIFF
--- a/custom_components/ha_hatch/config_flow.py
+++ b/custom_components/ha_hatch/config_flow.py
@@ -17,6 +17,8 @@ from .const import (
     CONFIG_TURN_ON_MEDIA,
     CONFIG_TURN_ON_LIGHT,
     CONFIG_TURN_ON_DEFAULT,
+    CONFIG_NUMBERED_PRESET_SCENES,
+    CONFIG_NUMBERED_PRESET_SCENES_DEFAULT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +38,13 @@ class HatchOptionFlowHandler(config_entries.OptionsFlow):
                     CONFIG_TURN_ON_MEDIA,
                     default=config_entry.options.get(
                         CONFIG_TURN_ON_MEDIA, CONFIG_TURN_ON_DEFAULT
+                    ),
+                ): bool,
+                vol.Required(
+                    CONFIG_NUMBERED_PRESET_SCENES,
+                    default=config_entry.options.get(
+                        CONFIG_NUMBERED_PRESET_SCENES,
+                        CONFIG_NUMBERED_PRESET_SCENES_DEFAULT,
                     ),
                 ): bool,
             }

--- a/custom_components/ha_hatch/const.py
+++ b/custom_components/ha_hatch/const.py
@@ -8,6 +8,8 @@ CONFIG_FLOW_VERSION: int = 2
 CONFIG_TURN_ON_MEDIA: str = "turn_on_media"
 CONFIG_TURN_ON_LIGHT: str = "turn_on_light"
 CONFIG_TURN_ON_DEFAULT: bool = True
+CONFIG_NUMBERED_PRESET_SCENES: str = "numbered_preset_scenes"
+CONFIG_NUMBERED_PRESET_SCENES_DEFAULT: bool = False
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,

--- a/custom_components/ha_hatch/favorites.py
+++ b/custom_components/ha_hatch/favorites.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def favorite_scene_name(
+    favorite_name: str,
+    preset_number: int,
+    show_preset_number: bool,
+) -> str:
+    if not show_preset_number:
+        return favorite_name
+
+    return f"Preset {preset_number} - {favorite_name}"
+
+
+def favorite_scene_attributes(
+    favorite: Mapping[str, Any],
+    preset_number: int,
+) -> dict[str, Any]:
+    return {
+        "preset_number": preset_number,
+        "hatch_favorite_id": favorite.get("id"),
+        "hatch_display_order": favorite.get("displayOrder"),
+    }

--- a/custom_components/ha_hatch/scene.py
+++ b/custom_components/ha_hatch/scene.py
@@ -1,40 +1,89 @@
 from __future__ import annotations
 
 import logging
-from homeassistant.components.scene import Scene
 from typing import Any
+
+from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HatchDataUpdateCoordinator
-from .const import DOMAIN
+from .const import (
+    CONFIG_NUMBERED_PRESET_SCENES,
+    CONFIG_NUMBERED_PRESET_SCENES_DEFAULT,
+    DOMAIN,
+)
+from .favorites import favorite_scene_attributes, favorite_scene_name
 from .hatch_entity import HatchEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     coordinator: HatchDataUpdateCoordinator = hass.data[DOMAIN]
-    scene_entities = []
+    show_preset_numbers = bool(
+        config_entry.options.get(
+            CONFIG_NUMBERED_PRESET_SCENES,
+            CONFIG_NUMBERED_PRESET_SCENES_DEFAULT,
+        )
+    )
+    scene_entities: list[RiotScene] = []
     for rest_device in coordinator.rest_devices:
         if hasattr(rest_device, "favorites") and isinstance(rest_device.favorites, list):
-            for favorite in rest_device.favorites:
+            for preset_number, favorite in enumerate(rest_device.favorites, start=1):
                 try:
-                    favorite_name, favorite_id = favorite['steps'][0]['name'], favorite['id']
+                    favorite_name = favorite["steps"][0]["name"]
+                    favorite_id = favorite["id"]
                 except (TypeError, KeyError, IndexError):
-                    _LOGGER.error(f"Error creating scene for {rest_device.thing_name} with favorite {favorite}. Skipping this favorite.")
+                    _LOGGER.error(
+                        f"Error creating scene for {rest_device.thing_name} "
+                        f"with favorite {favorite}. Skipping this favorite."
+                    )
                     continue
-                scene_entities.append(RiotScene(coordinator, rest_device.thing_name, favorite_name, favorite_id))
+                scene_entities.append(
+                    RiotScene(
+                        coordinator,
+                        rest_device.thing_name,
+                        favorite_scene_name(
+                            favorite_name,
+                            preset_number,
+                            show_preset_numbers,
+                        ),
+                        favorite_name,
+                        favorite_id,
+                        favorite_scene_attributes(favorite, preset_number),
+                    )
+                )
     async_add_entities(scene_entities)
 
 
 class RiotScene(HatchEntity, Scene):
-    def __init__(self, coordinator: HatchDataUpdateCoordinator, thing_name: str, name: str, favorite_id: int):
-        super().__init__(coordinator=coordinator, thing_name=thing_name, entity_type=f"Scene-{name}-{favorite_id}")
+    def __init__(
+        self,
+        coordinator: HatchDataUpdateCoordinator,
+        thing_name: str,
+        name: str,
+        favorite_name: str,
+        favorite_id: int,
+        extra_state_attributes: dict[str, Any],
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            thing_name=thing_name,
+            entity_type=f"Scene-{favorite_name}-{favorite_id}",
+        )
         self._attr_name = name
-        self.favorite_name_id = f"{name}-{favorite_id}"
-        _LOGGER.debug(f"scene; unique_id:{self._attr_unique_id}, name:{self._attr_name}, favorite_name_id:{self.favorite_name_id}")
+        self._attr_extra_state_attributes = extra_state_attributes
+        self.favorite_name_id = f"{favorite_name}-{favorite_id}"
+        _LOGGER.debug(
+            f"scene; unique_id:{self._attr_unique_id}, "
+            f"name:{self._attr_name}, favorite_name_id:{self.favorite_name_id}"
+        )
 
     def activate(self, **kwargs: Any) -> None:
         _LOGGER.debug(f"activating scene:{self.unique_id}")

--- a/custom_components/ha_hatch/strings.json
+++ b/custom_components/ha_hatch/strings.json
@@ -20,7 +20,8 @@
       "init": {
         "data": {
           "turn_on_media": "Auto turn on Rest+ when media play starts",
-          "turn_on_light": "Auto turn on Rest+ when light turns on"
+          "turn_on_light": "Auto turn on Rest+ when light turns on",
+          "numbered_preset_scenes": "Show preset numbers in favorite scene names"
         }
       }
     }

--- a/custom_components/ha_hatch/translations/en.json
+++ b/custom_components/ha_hatch/translations/en.json
@@ -20,7 +20,8 @@
       "init": {
         "data": {
           "turn_on_media": "Auto turn on Rest+ when media play starts",
-          "turn_on_light": "Auto turn on Rest+ when light turns on"
+          "turn_on_light": "Auto turn on Rest+ when light turns on",
+          "numbered_preset_scenes": "Show preset numbers in favorite scene names"
         }
       }
     }

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -1,0 +1,79 @@
+import unittest
+from collections.abc import Mapping
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Protocol, cast
+
+FAVORITES_MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "ha_hatch"
+    / "favorites.py"
+)
+
+
+class FavoritesModule(Protocol):
+    def favorite_scene_name(
+        self,
+        favorite_name: str,
+        preset_number: int,
+        show_preset_number: bool,
+    ) -> str:
+        ...
+
+    def favorite_scene_attributes(
+        self,
+        favorite: Mapping[str, Any],
+        preset_number: int,
+    ) -> dict[str, Any]:
+        ...
+
+
+def load_favorites_module() -> FavoritesModule:
+    spec = spec_from_file_location("ha_hatch_favorites", FAVORITES_MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Unable to load favorites module from {FAVORITES_MODULE_PATH}"
+        )
+
+    module: ModuleType = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(FavoritesModule, module)
+
+
+class FavoriteHelperTest(unittest.TestCase):
+    def test_favorite_scene_name_keeps_existing_name_by_default(self) -> None:
+        favorites = load_favorites_module()
+
+        self.assertEqual(
+            favorites.favorite_scene_name("Ocean", 1, False),
+            "Ocean",
+        )
+
+    def test_favorite_scene_name_can_include_preset_number(self) -> None:
+        favorites = load_favorites_module()
+
+        self.assertEqual(
+            favorites.favorite_scene_name("Forest Lake", 2, True),
+            "Preset 2 - Forest Lake",
+        )
+
+    def test_favorite_scene_attributes_include_preset_mapping(self) -> None:
+        favorites = load_favorites_module()
+
+        self.assertEqual(
+            favorites.favorite_scene_attributes(
+                {"id": 223167108, "displayOrder": 1},
+                2,
+            ),
+            {
+                "preset_number": 2,
+                "hatch_favorite_id": 223167108,
+                "hatch_display_order": 1,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an options-flow toggle to show Hatch preset numbers in favorite scene names
- preserve existing scene unique IDs by keeping them based on the favorite name and Hatch favorite id
- expose preset metadata as scene attributes: `preset_number`, `hatch_favorite_id`, and `hatch_display_order`
- add tests for the new scene naming and metadata helpers

## Why

The Hatch app presents favorite scenes as numbered presets. Exposing the same numbering in Home Assistant makes it easier to map automations and dashboards back to the device/app UI without breaking existing users by default.

## Testing

- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `uvx ruff check .`
- installed from fork on Home Assistant OS via HACS, ran `ha core check`, restarted Core, and verified the numbered preset scenes loaded
- activated `scene.home_hatch_preset_1_ocean` through Home Assistant and verified the Hatch media player reported favorite `222829658` / `Ocean`
