### PR TITLE
docs: add Restore 5 to tested devices and note full clock display control

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A custom integration for Hatch Rest/Restore Sound Machines. This project is most
 - Rest+ 2nd gen
 - Restore 2
 - Restore 3
+- Restore 5
 
 ## Feature Highlights ##
 - monitor device connectivity
@@ -27,6 +28,7 @@ A custom integration for Hatch Rest/Restore Sound Machines. This project is most
 - adjust light brightness and color
 - turn rest plus on and off
 - turn clock on and off and adjust brightness (Rest+ 2nd gen/Restore 3) 
+- full clock display control - separate day/night brightness, clock mode (Always On / Off at Night / Always Off), on/off schedule times, and tap-to-show (Restore 5)
 - enable, disable, and edit wake times for existing alarms (Restore, Restore 2, Restore 3)
 - turn Toddler Lock on and off (Rest+ 2nd gen) 
 - monitor device charging status (Rest+ 2nd gen)


### PR DESCRIPTION
Adds **Restore 5** to the Tested Devices list and documents the full clock display control (day/night brightness, clock mode, on/off schedule times, tap-to-show) shipped in #313 / v1.31.0. Tested on a Restore 5 (RestoreV5, fw 10.1.625).