### PR TITLE
fix: clock light targets the active day/night brightness channel in all modes

### DIFF
--- a/custom_components/ha_hatch/light_riot_clock_entity.py
+++ b/custom_components/ha_hatch/light_riot_clock_entity.py
@@ -33,12 +33,11 @@ def _parse_clock_time(value: str | None) -> dt_time | None:
 def _clock_active_is_daytime(dev) -> bool:
     """Return True when the device is currently showing its daytime brightness.
 
-    Only the "custom" (Off at Night) schedule splits day/night; the daytime
-    channel is active between turnBrightAt and turnDimAt. In every other mode the
-    hardware displays the nighttime channel.
+    The daytime channel is active between turnBrightAt and turnDimAt, the
+    nighttime channel otherwise. This applies whenever the clock is on (Always
+    On and Off at Night) - the mode only controls when the display turns fully
+    off, not which brightness is shown.
     """
-    if getattr(dev, "clock_turn_off_mode", None) != "custom":
-        return False
     bright_at = _parse_clock_time(getattr(dev, "clock_turn_bright_at", None))
     dim_at = _parse_clock_time(getattr(dev, "clock_turn_dim_at", None))
     if bright_at is None or dim_at is None:


### PR DESCRIPTION
The clock light was choosing between the daytime and nighttime brightness channels only in `Off at Night` (`turnOffMode == custom`) mode, and always using the nighttime channel otherwise. On real hardware the device switches brightness channels purely on the `turnBrightAt` -> `turnDimAt` schedule in **every** mode where the clock is on - the mode only controls when the display turns fully off, not which brightness is shown.

Result: in **Always On** mode during the day, the clock light slider drove the *nighttime* channel while the device was actually displaying the *daytime* channel (verified on a Restore 5, fw 10.1.625).

Fix: drop the `mode == custom` gate in `_clock_active_is_daytime` so the day/night decision is time-of-day based (`turnBrightAt` -> `turnDimAt`) regardless of mode. The `number` entities (which set each channel independently) are unaffected.

Tested locally on a Restore 5.