### PR TITLE
fix: never wait on mqtt disconnect in the event loop, add timeouts

### DIFF
--- a/custom_components/ha_hatch/hatch_data_update_coordinator.py
+++ b/custom_components/ha_hatch/hatch_data_update_coordinator.py
@@ -20,6 +20,7 @@ from custom_components.ha_hatch import DOMAIN
 _LOGGER: Logger = getLogger(__name__)
 
 ALARM_REFRESH_INTERVAL: Final = timedelta(minutes=10)
+MQTT_DISCONNECT_TIMEOUT: Final = 10
 DEFAULT_RETRY_INTERVAL: Final = timedelta(minutes=1)
 RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(minutes=15)
 MAX_RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(hours=6)
@@ -60,12 +61,25 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             always_update=False,
         )
 
-    def _disconnect_mqtt(self) -> None:
-        if self.mqtt_connection is not None:
-            try:
-                self.mqtt_connection.disconnect().result()
-            except Exception as error:
-                _LOGGER.error("mqtt_connection disconnect failed during reconnect", exc_info=error)
+    async def _async_disconnect_mqtt(self) -> None:
+        # disconnect() returns a future that never resolves if the connection
+        # is already broken; waiting on it without a timeout on the event loop
+        # freezes all of Home Assistant.
+        if self.mqtt_connection is None:
+            return
+        mqtt_connection = self.mqtt_connection
+        self.mqtt_connection = None
+
+        def _disconnect() -> None:
+            mqtt_connection.disconnect().result(timeout=MQTT_DISCONNECT_TIMEOUT)
+
+        try:
+            await asyncio.wait_for(
+                self.hass.async_add_executor_job(_disconnect),
+                timeout=MQTT_DISCONNECT_TIMEOUT * 2,
+            )
+        except Exception as error:
+            _LOGGER.error("mqtt_connection disconnect failed during reconnect", exc_info=error)
 
     def _rest_device_unsub(self) -> None:
         for rest_device in self.rest_devices:
@@ -215,7 +229,7 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._raise_if_retry_backoff_active()
         try:
             _LOGGER.debug(f"_async_update_data: {self.email}")
-            self._disconnect_mqtt()
+            await self._async_disconnect_mqtt()
             self._rest_device_unsub()
 
             from hatch_rest_api import get_rest_devices
@@ -286,7 +300,7 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self._alarm_refresh_unsub()
             self._alarm_refresh_unsub = None
         self._alarm_refresh_callbacks.clear()
-        self._disconnect_mqtt()
+        await self._async_disconnect_mqtt()
         self._rest_device_unsub()
         await super().async_shutdown()
 


### PR DESCRIPTION
## Summary

`_disconnect_mqtt` calls `self.mqtt_connection.disconnect().result()` with no timeout, and it runs directly in the event loop (called from `_async_update_data` and `async_shutdown`). When the connection is already broken — e.g. during a Hatch cloud outage — that future never resolves, which freezes Home Assistant's event loop entirely: UI, automations, and recorder all stop.

This PR replaces it with `_async_disconnect_mqtt`, which:

- runs the disconnect in an executor thread via `hass.async_add_executor_job`, so the event loop is never blocked
- bounds the wait with `result(timeout=10)`
- adds an outer `asyncio.wait_for` guard so even a wedged native `disconnect()` call can't stall the coordinator for more than 20 s
- clears `self.mqtt_connection` up front so a failed disconnect abandons the dead connection instead of retrying it

Likely fixes the class of reports in #261.

## Real-world incident

During a Hatch cloud outage on 2026-07-24, a Home Assistant instance (2026.6.1, ha_hatch v1.30.0) froze completely at 4:41 AM when the coordinator refreshed against the dead connection. The Supervisor watchdog restarted core repeatedly and every restart froze again ~2 minutes in (recorder evidence: 4 consecutive `recorder_runs` with `closed_incorrect`, each dying right after startup). Only disabling the integration stopped the loop. The connect-side companion fix is dahlb/hatch_rest_api#69.

## Testing

- `pytest tests/` — 9 passed
- `ruff check` — clean
- The patched coordinator is deployed on the affected instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUv54T1tjc6TJYCsUXyPE2