### PR TITLE
fix: bump hatch_rest_api to 1.34.1 for mqtt connect timeout

### DIFF
--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
   "loggers": ["ha_hatch", "hatch_rest_api"],
-  "requirements": ["hatch_rest_api==1.34.0"],
+  "requirements": ["hatch_rest_api==1.34.1"],
   "version": "1.31.2"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant==2025.1.0
 ruff==0.15.22
-hatch-rest-api==1.34.0
+hatch-rest-api==1.34.1


### PR DESCRIPTION
Follow-up to #320: hatch_rest_api 1.34.1 (dahlb/hatch_rest_api#69) adds the timeout on the MQTT connect future, but the manifest still pins 1.34.0, so installs don't pick it up. This bumps the pin so both halves of the hang fix ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUv54T1tjc6TJYCsUXyPE2