### PR TITLE
fix: unsubscribe device shadows before tearing down the mqtt connection

### DIFF
--- a/custom_components/ha_hatch/hatch_data_update_coordinator.py
+++ b/custom_components/ha_hatch/hatch_data_update_coordinator.py
@@ -21,6 +21,7 @@ _LOGGER: Logger = getLogger(__name__)
 
 ALARM_REFRESH_INTERVAL: Final = timedelta(minutes=10)
 MQTT_DISCONNECT_TIMEOUT: Final = 10
+MQTT_UNSUBSCRIBE_TIMEOUT: Final = 10
 DEFAULT_RETRY_INTERVAL: Final = timedelta(minutes=1)
 RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(minutes=15)
 MAX_RATE_LIMIT_RETRY_INTERVAL: Final = timedelta(hours=6)
@@ -60,6 +61,37 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             name=f"{DOMAIN}-{self.email}",
             always_update=False,
         )
+
+    async def _async_unsubscribe_shadows(self) -> None:
+        # Every device holds two AWS IoT shadow subscriptions, and awscrt keeps
+        # a native reference to each subscription callback. Those references are
+        # invisible to Python's garbage collector, so dropping our own reference
+        # to the device is not enough to reclaim it -- the device, its shadow
+        # client and the TLS context underneath survive until the subscriptions
+        # go away. Skipping this stranded one connection graph per reconnect,
+        # which is hourly, for as long as the process ran.
+        #
+        # Has to happen before the disconnect below, while the connection can
+        # still carry the UNSUBSCRIBE, and off the event loop because the
+        # library call blocks waiting for each UNSUBACK.
+        if not self.rest_devices:
+            return
+
+        rest_devices = self.rest_devices
+
+        def _unsubscribe() -> None:
+            for rest_device in rest_devices:
+                rest_device.unsubscribe()
+
+        try:
+            await asyncio.wait_for(
+                self.hass.async_add_executor_job(_unsubscribe),
+                timeout=MQTT_UNSUBSCRIBE_TIMEOUT * 2,
+            )
+        except Exception as error:
+            # Best effort: a failure here costs memory, not correctness, and the
+            # reconnect matters more than the cleanup.
+            _LOGGER.error("shadow unsubscribe failed during teardown", exc_info=error)
 
     async def _async_disconnect_mqtt(self) -> None:
         # disconnect() returns a future that never resolves if the connection
@@ -229,6 +261,7 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._raise_if_retry_backoff_active()
         try:
             _LOGGER.debug(f"_async_update_data: {self.email}")
+            await self._async_unsubscribe_shadows()
             await self._async_disconnect_mqtt()
             self._rest_device_unsub()
 
@@ -300,6 +333,7 @@ class HatchDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self._alarm_refresh_unsub()
             self._alarm_refresh_unsub = None
         self._alarm_refresh_callbacks.clear()
+        await self._async_unsubscribe_shadows()
         await self._async_disconnect_mqtt()
         self._rest_device_unsub()
         await super().async_shutdown()

--- a/custom_components/ha_hatch/manifest.json
+++ b/custom_components/ha_hatch/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_hatch/issues",
   "loggers": ["ha_hatch", "hatch_rest_api"],
-  "requirements": ["hatch_rest_api==1.34.2"],
+  "requirements": ["hatch_rest_api==1.34.4"],
   "version": "1.31.4"
 }


### PR DESCRIPTION
## Summary
Every device holds two AWS IoT shadow subscriptions. awscrt keeps a native
reference to each subscription callback, which pins the whole connection
graph in memory. On MQTT reconnect the coordinator tore down the connection
without ever unsubscribing, so each reconnect leaked a `RestIot` object and
its subscriptions indefinitely.

This adds a teardown step that unsubscribes every device's shadow topics
before disconnecting, using the new `RestDevice.unsubscribe()` released in
`hatch_rest_api` 1.34.4 (dahlb/hatch_rest_api#76). `manifest.json` is bumped
to pin that version.

## Verification
Deployed to my own Home Assistant instance for several days alongside a
companion fix (dahlb/hatch_rest_api#75, also merged) for a related
`ClientBootstrap` thread leak:

- `profiler.dump_log_objects type=RestIot` returned exactly 1 live object
  (my actual device count) after 16h uptime, versus 140 before this fix
  (an exact 1-per-hour leak signature matching hourly MQTT reconnects).
- A 72h RSS soak test showed the process's `Private_Dirty` growth rate drop
  from +33.3 MB/day to +0.7 MB/day (essentially flat) over an identical
  uptime window measured before and after the fix.

## Test plan
- [x] `ruff check .` passes clean
- [x] Manually verified against a live Hatch Rest device over multiple days
- [ ] No coordinator-level automated tests exist upstream to extend (only
      `test_alarm_helpers.py` / `test_favorites.py`); happy to add some if
      you'd like a particular shape.